### PR TITLE
update-bcd: Replace klaw with fdir

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
         "eslint-plugin-unicorn": "^48.0.1",
         "fdir": "6.1.0",
         "json3": "3.3.3",
-        "klaw": "4.1.0",
         "listr2": "6.6.1",
         "minimatch": "9.0.3",
         "mocha": "10.2.0",
@@ -8098,15 +8097,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/klaw": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.1.0.tgz",
-      "integrity": "sha512-1zGZ9MF9H22UnkpVeuaGKOjfA2t6WrfdrJmGjy16ykcjnKQDmHVX+KI477rpbGevz/5FD4MC3xf1oxylBgcaQw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.14.0"
       }
     },
     "node_modules/kuler": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "eslint-plugin-unicorn": "^48.0.1",
     "fdir": "6.1.0",
     "json3": "3.3.3",
-    "klaw": "4.1.0",
     "listr2": "6.6.1",
     "minimatch": "9.0.3",
     "mocha": "10.2.0",

--- a/scripts/update-bcd.ts
+++ b/scripts/update-bcd.ts
@@ -29,7 +29,7 @@ import {
 } from "compare-versions";
 import esMain from "es-main";
 import fs from "fs-extra";
-import klaw from "klaw";
+import {fdir} from "fdir";
 import {Minimatch} from "minimatch";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
@@ -579,25 +579,21 @@ export const update = (
 export const loadJsonFiles = async (
   paths: string[],
 ): Promise<{[filename: string]: any}> => {
-  // Ignores .DS_Store, .git, etc.
-  const dotFilter = (item) => {
-    const basename = path.basename(item);
-    return basename === "." || basename[0] !== ".";
-  };
+  const jsonCrawler = new fdir()
+    .withFullPaths()
+    .filter((item) => {
+      // Ignores .DS_Store, .git, etc.
+      const basename = path.basename(item);
+      return basename === "." || basename[0] !== ".";
+    })
+    .filter((item) => item.endsWith(".json"));
 
   const jsonFiles: string[] = [];
 
   for (const p of paths) {
-    await new Promise((resolve, reject) => {
-      klaw(p, {filter: dotFilter})
-        .on("data", (item) => {
-          if (item.path.endsWith(".json")) {
-            jsonFiles.push(item.path);
-          }
-        })
-        .on("error", reject)
-        .on("end", resolve);
-    });
+    for (const item of await jsonCrawler.crawl(p).withPromise()) {
+      jsonFiles.push(item);
+    }
   }
 
   const entries = await Promise.all(


### PR DESCRIPTION
#### Summary

Replace klaw with fdir.

#### Further Info

The [PR putting update script into BCD](https://github.com/mdn/browser-compat-data/pull/19971) replaced klaw to avoid adding the dependency to BCD. The update script is the only use of klaw. Bringing this to collector, we can drop the klaw dependency.

#### Related Issues

https://github.com/mdn/browser-compat-data/issues/19868
https://github.com/mdn/browser-compat-data/pull/19971