### PR TITLE
Add report json schema

### DIFF
--- a/types/report.md
+++ b/types/report.md
@@ -1,7 +1,6 @@
 # The report JSON schema
 
-This document details the structure of reports produced by
-https://mdn-bcd-collector.appspot.com/ and potentially other tooling.
+This document details the structure of reports produced by https://mdn-bcd-collector.gooborg.com/.
 
 ## JSON structure
 
@@ -11,7 +10,7 @@ Below is an example of the report data:
 {
   "__version": "10.2.4",
   "results": {
-    "https://mdn-bcd-collector.example/tests/": [
+    "https://mdn-bcd-collector.gooborg.com/tests/": [
       {
         "exposure": "ServiceWorker",
         "name": "api.AbortController.AbortController",

--- a/types/report.md
+++ b/types/report.md
@@ -1,0 +1,62 @@
+# The report JSON schema
+
+This document details the structure of reports produced by
+https://mdn-bcd-collector.appspot.com/ and potentially other tooling.
+
+## JSON structure
+
+Below is an example of the report data:
+
+```json
+{
+  "__version": "10.2.4",
+  "results": {
+    "https://mdn-bcd-collector.example/tests/": [
+      {
+        "exposure": "ServiceWorker",
+        "name": "api.AbortController.AbortController",
+        "result": false
+      },
+      {
+        "exposure": "Window",
+        "message": "threw TypeError: Array.isArray is not a function",
+        "name": "api.AbortController.AbortController",
+        "result": null
+      }
+    ]
+  },
+  "userAgent": "Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.8) Gecko/20051111 Firefox/1.5"
+}
+```
+
+## Properties
+
+### `exposure`
+
+The `exposure` string is a required property. It must be one of four values whether the test was executed in a window (`"Window"`), dedicated worker (`"Worker"`), shared worker (`"SharedWorker"`) or service worker (`"ServiceWorker"`).
+
+### `message`
+
+The `message` string is a required property if `result` is `null` and optional if `result` is a `boolean`.
+
+The message can be an error message from the browser or from the test framework, for example "threw TypeError: Failed to construct 'Notification': Illegal constructor." or "Browser does not support detection methods" respectively.
+
+### `name`
+
+The `name` string is a required property and represents the feature identifier the result is for. The identifier is a dot-separated path commonly used in BCD. For example, "javascript.builtins.Array.at" refers to the feature at `{"javascript": {"builtins": {"Array": {"at": {"__compat": ...}}}}}`.
+
+### `result`
+
+The `result` boolean or `null` value is a required property indicating if the tested feature under the given `exposure` is present, not present, or cannot be determined by the test.
+
+### `__version`
+
+The `__version` string is a required property and the version of mdn-bcd-collector that collected the report.
+
+### `results`
+
+The `results` object is a required property and maps the collection page endpoint to an array of test results. There must be at least one key in the map.
+
+### `userAgent`
+
+The `userAgent` string is a required property and states the user agent of the tested browser the results were collected from.

--- a/types/report.schema.json
+++ b/types/report.schema.json
@@ -4,7 +4,13 @@
   "definitions": {
     "exposure": {
       "type": "string",
-      "enum": ["ServiceWorker", "SharedWorker", "Window", "Worker", "WebAssembly"]
+      "enum": [
+        "ServiceWorker",
+        "SharedWorker",
+        "Window",
+        "Worker",
+        "WebAssembly"
+      ]
     },
 
     "feature_name": {
@@ -23,10 +29,10 @@
         {
           "type": "object",
           "properties": {
-            "exposure": { "$ref": "#/definitions/exposure" },
-            "message": { "$ref": "#/definitions/result_message" },
-            "name": { "$ref": "#/definitions/feature_name" },
-            "result": { "type": "boolean" }
+            "exposure": {"$ref": "#/definitions/exposure"},
+            "message": {"$ref": "#/definitions/result_message"},
+            "name": {"$ref": "#/definitions/feature_name"},
+            "result": {"type": "boolean"}
           },
           "additionalProperties": false,
           "required": ["exposure", "name", "result"]
@@ -34,10 +40,10 @@
         {
           "type": "object",
           "properties": {
-            "exposure": { "$ref": "#/definitions/exposure" },
-            "message": { "$ref": "#/definitions/result_message" },
-            "name": { "$ref": "#/definitions/feature_name" },
-            "result": { "type": "null" }
+            "exposure": {"$ref": "#/definitions/exposure"},
+            "message": {"$ref": "#/definitions/result_message"},
+            "name": {"$ref": "#/definitions/feature_name"},
+            "result": {"type": "null"}
           },
           "additionalProperties": false,
           "required": ["exposure", "message", "name", "result"]

--- a/types/report.schema.json
+++ b/types/report.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "definitions": {
+    "exposure": {
+      "type": "string",
+      "enum": ["ServiceWorker", "SharedWorker", "Window", "Worker", "WebAssembly"]
+    },
+
+    "feature_name": {
+      "type": "string",
+      "pattern": "^[a-zA-Z_0-9-$@.]*$",
+      "description": "Dot separated identifier path.\n\n@example \"javascript.builtins.Array.at\""
+    },
+
+    "result_message": {
+      "type": "string",
+      "description": "An error message from the browser or from the test framework.\n\n@example \"threw TypeError: Failed to construct 'Notification': Illegal constructor.\"\n@example \"Testing CanvasRenderingContext2D in workers is not yet implemented\"\n@example \"Browser does not support detection methods\""
+    },
+
+    "collector_result": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "exposure": { "$ref": "#/definitions/exposure" },
+            "message": { "$ref": "#/definitions/result_message" },
+            "name": { "$ref": "#/definitions/feature_name" },
+            "result": { "type": "boolean" }
+          },
+          "additionalProperties": false,
+          "required": ["exposure", "name", "result"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exposure": { "$ref": "#/definitions/exposure" },
+            "message": { "$ref": "#/definitions/result_message" },
+            "name": { "$ref": "#/definitions/feature_name" },
+            "result": { "type": "null" }
+          },
+          "additionalProperties": false,
+          "required": ["exposure", "message", "name", "result"]
+        }
+      ]
+    }
+  },
+
+  "title": "Report",
+  "type": "object",
+  "properties": {
+    "__version": {
+      "type": "string",
+      "pattern": "^[0-9.]+$",
+      "description": "Version of mdn-bcd-collector that collected the report."
+    },
+    "extensions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "results": {
+      "type": "object",
+      "patternProperties": {
+        "^.*://.*$": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/collector_result"
+          }
+        }
+      },
+      "minProperties": 1
+    },
+    "userAgent": {
+      "type": "string",
+      "description": "User agent of tested browser."
+    }
+  },
+  "required": ["__version", "results", "userAgent"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
#### Summary

Add json schema for report produced by the app.

#### Further Info

Based on the [PR that added the schema for this file to BCD](https://github.com/mdn/browser-compat-data/pull/19941) with some changes:

- Add `WebAssembly` value to `exposure`.
- `$schema` changed to `http://json-schema.org/draft-07/schema#`. The previous `http://json-schema.org/schema` currently 404s.
- Updated `__version` example in markdown document to `10.2.4`, the latest in mdn-bcd-results.

#### Related Issues

https://github.com/mdn/browser-compat-data/issues/19868
https://github.com/mdn/browser-compat-data/pull/19941