### PR TITLE
Remove left_right from text-underline-position

### DIFF
--- a/custom/css.json
+++ b/custom/css.json
@@ -886,8 +886,6 @@
       }
     },
     "text-underline-position": {
-      "__additional_values": {
-      },
       "__values": ["auto-pos", "from-font", "left", "right", "under"]
     },
     "text-underline-style": {},

--- a/custom/css.json
+++ b/custom/css.json
@@ -887,8 +887,7 @@
     },
     "text-underline-position": {
       "__additional_values": {
-        "above_below": ["above", "below"],
-        "left_right": ["left", "right"]
+        "above_below": ["above", "below"]
       },
       "__values": ["auto-pos", "from-font", "left", "right", "under"]
     },

--- a/custom/css.json
+++ b/custom/css.json
@@ -887,7 +887,6 @@
     },
     "text-underline-position": {
       "__additional_values": {
-        "above_below": ["above", "below"]
       },
       "__values": ["auto-pos", "from-font", "left", "right", "under"]
     },


### PR DESCRIPTION
Was removed in BCD in https://github.com/mdn/browser-compat-data/pull/21022