### PR TITLE
Only test new_required & empty ctor on relevant ctors

### DIFF
--- a/test-builder/javascript.test.ts
+++ b/test-builder/javascript.test.ts
@@ -132,14 +132,6 @@ describe("build (JavaScript)", () => {
         code: '(function () {\n  if (!("Object" in self)) {\n    return { result: false, message: "Object is not defined" };\n  }\n  return bcd.testConstructor("Object", false);\n})();\n',
         exposure: ["Window"],
       },
-      "javascript.builtins.Object.Object.new_required": {
-        code: '(function () {\n  if (!("Object" in self)) {\n    return { result: false, message: "Object is not defined" };\n  }\n  return bcd.testConstructorNewRequired("Object");\n})();\n',
-        exposure: ["Window"],
-      },
-      "javascript.builtins.Object.Object.constructor_without_parameters": {
-        code: '(function () {\n  if (!("Object" in self)) {\n    return { result: false, message: "Object is not defined" };\n  }\n  try {\n    new Object();\n    return true;\n  } catch (e) {\n    return { result: false, message: e.message };\n  }\n})();\n',
-        exposure: ["Window"],
-      },
       "javascript.builtins.Object.assign": {
         code: '"Object" in self && "assign" in Object',
         exposure: ["Window"],
@@ -174,10 +166,6 @@ describe("build (JavaScript)", () => {
 `,
         exposure: ["Window"],
       },
-      "javascript.builtins.AggregateError.AggregateError.new_required": {
-        code: '(function () {\n  if (!("AggregateError" in self)) {\n    return { result: false, message: "AggregateError is not defined" };\n  }\n  return bcd.testConstructorNewRequired("AggregateError");\n})();\n',
-        exposure: ["Window"],
-      },
       "javascript.builtins.Array": {
         code: '"Array" in self',
         exposure: ["Window"],
@@ -198,10 +186,6 @@ describe("build (JavaScript)", () => {
   return bcd.testConstructor("Array", false);
 })();
 `,
-        exposure: ["Window"],
-      },
-      "javascript.builtins.Array.Array.new_required": {
-        code: '(function () {\n  if (!("Array" in self)) {\n    return { result: false, message: "Array is not defined" };\n  }\n  return bcd.testConstructorNewRequired("Array");\n})();\n',
         exposure: ["Window"],
       },
       "javascript.builtins.Array.at": {

--- a/test-builder/javascript.ts
+++ b/test-builder/javascript.ts
@@ -243,35 +243,68 @@ const buildConstructorTests = async (tests, path: string, data: any = {}) => {
   }
 
   if (!data.no_new) {
-    tests[`${path}.new_required`] = compileTest({
-      raw: {
-        code: (
-          await compileCustomTest(
-            baseCode + `return bcd.testConstructorNewRequired("${iface}")`,
-          )
-        ).code,
-      },
-      exposure: ["Window"],
-    });
+    const relevantCtors = [
+      "ArrayBuffer",
+      "DataView",
+      "Float32Array",
+      "Float64Array",
+      "Int16Array",
+      "Int32Array",
+      "Int8Array",
+      "Map",
+      "Set",
+      "TypedArray",
+      "Uint16Array",
+      "Uint32Array",
+      "Uint8Array",
+      "Uint8ClampedArray",
+      "WeakMap",
+    ];
+    if (relevantCtors.includes(iface)) {
+      tests[`${path}.new_required`] = compileTest({
+        raw: {
+          code: (
+            await compileCustomTest(
+              baseCode + `return bcd.testConstructorNewRequired("${iface}")`,
+            )
+          ).code,
+        },
+        exposure: ["Window"],
+      });
+    }
   }
 
   if (data.optional_args) {
-    tests[`${path}.constructor_without_parameters`] = compileTest({
-      raw: {
-        code: (
-          await compileCustomTest(
-            baseCode +
-              `try {
+    const relevantCtors = [
+      "Float32Array",
+      "Float64Array",
+      "Int16Array",
+      "Int32Array",
+      "Int8Array",
+      "TypedArray",
+      "Uint16Array",
+      "Uint32Array",
+      "Uint8Array",
+      "Uint8ClampedArray",
+    ];
+    if (relevantCtors.includes(iface)) {
+      tests[`${path}.constructor_without_parameters`] = compileTest({
+        raw: {
+          code: (
+            await compileCustomTest(
+              baseCode +
+                `try {
             new ${iface}();
             return true;
           } catch(e) {
             return {result: false, message: e.message};
           }`,
-          )
-        ).code,
-      },
-      exposure: ["Window"],
-    });
+            )
+          ).code,
+        },
+        exposure: ["Window"],
+      });
+    }
   }
 
   // Add the additional tests


### PR DESCRIPTION
Currently, the collector proposes to add "constructor_without_parameters" and "new_required" as new subfeatures to many constructors that have this requirement. We don't need to add this everywhere, though. It is only interesting to those constructors which historically shipped without these requirements. 