### PR TITLE
Fix JS alternate names

### DIFF
--- a/custom/js.json
+++ b/custom/js.json
@@ -14,7 +14,6 @@
     "ArrayBuffer": {
       "members": {"instance": ["maxByteLength", "resizable", "resize"]}
     },
-    "Atomics": {"members": {"static": ["wake"]}},
     "Boolean": {
       "members": {"instance": ["toSource"]}
     },
@@ -128,10 +127,8 @@
         "instance": [
           "baseName",
           "calendar",
-          "calendars",
           "caseFirst",
           "collation",
-          "collations",
           "getCalendars",
           "getCollations",
           "getHourCycles",
@@ -140,19 +137,14 @@
           "getTimeZones",
           "getWeekInfo",
           "hourCycle",
-          "hourCycles",
           "language",
           "maximize",
           "minimize",
           "numberingSystem",
-          "numberingSystems",
           "numeric",
           "region",
           "script",
-          "textInfo",
-          "timeZones",
-          "toString",
-          "weekInfo"
+          "toString"
         ]
       }
     },

--- a/test-builder/javascript.ts
+++ b/test-builder/javascript.ts
@@ -24,25 +24,17 @@ const stripAttrName = (name, featureName) =>
     .replace(/__(\w+)__/g, "$1");
 
 const shouldIgnoreAttr = (featureName: string, attrName: string) => {
-  const prototypeString = `${featureName}.prototype`;
-  if (attrName === prototypeString) {
+  const ignoreList = [
+    "String.prototype.trimLeft()",
+    "String.prototype.trimRight()",
+  ];
+
+  if (ignoreList.includes(attrName)) {
+    return true;
+  }
+
+  if (attrName === `${featureName}.prototype`) {
     // Skip the prototype itself
-    return true;
-  }
-
-  if (
-    featureName === "Atomics" &&
-    ["WaiterRecord", "WaiterListRecords"].includes(attrName)
-  ) {
-    // The spec defines WaiterRecord/WaiterListRecords as if they were members of Atomics
-    return true;
-  }
-
-  if (
-    featureName === "String" &&
-    ["trimLeft", "trimRight"].includes(attrName)
-  ) {
-    // The spec defines these deprecated aliases for trimStart and trimEnd
     return true;
   }
 


### PR DESCRIPTION
Fix https://github.com/openwebdocs/mdn-bcd-collector/issues/854

- Remove Atomics.wake and old Intl.Locale members from customJS
- Properly ignore String.prototype.trimLeft/Right
- Remove ignore case for WaiterRecord and WaiterListRecords, seems unneeded. 