### PR TITLE
Don't add TypedArray as a ctor

### DIFF
--- a/test-builder/javascript.ts
+++ b/test-builder/javascript.ts
@@ -88,6 +88,12 @@ const buildTestList = (specJS, customJS) => {
       continue;
     }
 
+    // %TypedArray% is an abstract class and there is no constructor
+    if (feat.name === "TypedArray") {
+      delete feat.ctor;
+      continue;
+    }
+
     features[featureName] = {members: {static: [], instance: []}};
 
     // If there is a constructor, determine parameters


### PR DESCRIPTION
Currently `add-new-bcd` proposes to add a constructor for TypedArray. This PR stops that.