### PR TITLE
Don't skip out of loop when collecting TypedArray test list

### DIFF
--- a/test-builder/javascript.ts
+++ b/test-builder/javascript.ts
@@ -91,7 +91,6 @@ const buildTestList = (specJS, customJS) => {
     // %TypedArray% is an abstract class and there is no constructor
     if (feat.name === "TypedArray") {
       delete feat.ctor;
-      continue;
     }
 
     features[featureName] = {members: {static: [], instance: []}};


### PR DESCRIPTION
I made a mistake in https://github.com/openwebdocs/mdn-bcd-collector/pull/874. (copy pasted from the above code but the `continue` makes no sense here as the TypedArray members should still be collected, just the constructor should be ignored)