### PR TITLE
Collect CSS selectors

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -4831,49 +4831,55 @@ css:
       return bcd.testCSSProperty('aspect-ratio', '16 / 9');
   selectors:
     next-sibling: |-
-      return CSS.supports('selector(div + span)');
+      return bcd.testCSSSelector('div + span');
     child: |-
-      return CSS.supports('selector(div > span)');
+      return bcd.testCSSSelector('div > span');
     column: |-
-      return CSS.supports('selector(div || span)');
+      return bcd.testCSSSelector('div || span');
     subsequent-sibling: |-
-      return CSS.supports('selector(div ~ span)');
+      return bcd.testCSSSelector('div ~ span');
     cue: |-
-      return CSS.supports('selector(video::cue)');
+      return bcd.testCSSSelector('video::cue');
     highlight: |-
-      return CSS.supports('selector(::highlight(rainbow-color-1))');
+      return bcd.testCSSSelector('::highlight(rainbow-color-1)');
     part: |-
-      return CSS.supports('selector(::part(tab))');
+      return bcd.testCSSSelector('::part(tab)');
     slotted: |-
-      return CSS.supports('selector(::slotted(*))');
-    view-transition-group: return CSS.supports('selector(::view-transition-group(*))');
-    view-transition-image-pair: return CSS.supports('selector(::view-transition-image-pair(*))');
-    view-transition-new: return CSS.supports('selector(::view-transition-new(*))');
-    view-transition-old: return CSS.supports('selector(::view-transition-old(*))');
-    active-view-transition: return CSS.supports('selector(:root:active-view-transition(*))');
-    dir: return CSS.supports('selector(:dir(ltr))');
+      return bcd.testCSSSelector('::slotted(*)');
+    view-transition-group: |-
+      return bcd.testCSSSelector('::view-transition-group(*)');
+    view-transition-image-pair: |-
+      return bcd.testCSSSelector('::view-transition-image-pair(*)');
+    view-transition-new: |-
+      return bcd.testCSSSelector('::view-transition-new(*)');
+    view-transition-old: |-
+      return bcd.testCSSSelector('::view-transition-old(*)');
+    active-view-transition: |-
+      return bcd.testCSSSelector(':root:active-view-transition(*)');
+    dir: |-
+      return bcd.testCSSSelector(':dir(ltr)');
     has: |-
-      return CSS.supports('selector(:has(+ *))');
+      return bcd.testCSSSelector(':has(+ *)');
     host: |-
-      return CSS.supports('selector(:host(h1))');
+      return bcd.testCSSSelector(':host(h1)');
     host-context: |-
-      return CSS.supports('selector(:host-context(h1))');
+      return bcd.testCSSSelector(':host-context(h1)');
     is: |-
-      return CSS.supports('selector(:is(h1))');
+      return bcd.testCSSSelector(':is(h1)');
     lang: |-
-      return CSS.supports('selector(:lang(en-US))');
+      return bcd.testCSSSelector(':lang(en-US)');
     not: |-
-      return CSS.supports('selector(:not(strong))');
+      return bcd.testCSSSelector(':not(strong)');
     nth-child: |-
-      return CSS.supports('selector(:nth-child(even)')
+      return bcd.testCSSSelector(':nth-child(even)');
     nth-last-child: |-
-      return CSS.supports('selector(:nth-last-child(even)')
+      return bcd.testCSSSelector(':nth-last-child(even)');
     nth-last-of-type: |-
-      return CSS.supports('selector(:nth-last-of-type(even)')
+      return bcd.testCSSSelector(':nth-last-of-type(even)');
     nth-of-type: |-
-      return CSS.supports('selector(:nth-of-type(even)')
+      return bcd.testCSSSelector(':nth-of-type(even)');
     where: |-
-      return CSS.supports('selector(:where(ol, ul))');
+      return bcd.testCSSSelector(':where(ol, ul)');
     first: |-
       return {result: null, message: 'Testing :first is not yet implemented'};
     left: |-

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -4829,6 +4829,57 @@ css:
       'env(--foo)');
     aspect-ratio: |-
       return bcd.testCSSProperty('aspect-ratio', '16 / 9');
+  selectors:
+    next-sibling: |-
+      return CSS.supports('selector(div + span)');
+    child: |-
+      return CSS.supports('selector(div > span)');
+    column: |-
+      return CSS.supports('selector(div || span)');
+    subsequent-sibling: |-
+      return CSS.supports('selector(div ~ span)');
+    cue: |-
+      return CSS.supports('selector(video::cue)');
+    highlight: |-
+      return CSS.supports('selector(::highlight(rainbow-color-1))');
+    part: |-
+      return CSS.supports('selector(::part(tab))');
+    slotted: |-
+      return CSS.supports('selector(::slotted(*))');
+    view-transition-group: return CSS.supports('selector(::view-transition-group(*))');
+    view-transition-image-pair: return CSS.supports('selector(::view-transition-image-pair(*))');
+    view-transition-new: return CSS.supports('selector(::view-transition-new(*))');
+    view-transition-old: return CSS.supports('selector(::view-transition-old(*))');
+    active-view-transition: return CSS.supports('selector(:root:active-view-transition(*))');
+    dir: return CSS.supports('selector(:dir(ltr))');
+    has: |-
+      return CSS.supports('selector(:has(+ *))');
+    host: |-
+      return CSS.supports('selector(:host(h1))');
+    host-context: |-
+      return CSS.supports('selector(:host-context(h1))');
+    is: |-
+      return CSS.supports('selector(:is(h1))');
+    lang: |-
+      return CSS.supports('selector(:lang(en-US))');
+    not: |-
+      return CSS.supports('selector(:not(strong))');
+    nth-child: |-
+      return CSS.supports('selector(:nth-child(even)')
+    nth-last-child: |-
+      return CSS.supports('selector(:nth-last-child(even)')
+    nth-last-of-type: |-
+      return CSS.supports('selector(:nth-last-of-type(even)')
+    nth-of-type: |-
+      return CSS.supports('selector(:nth-of-type(even)')
+    where: |-
+      return CSS.supports('selector(:where(ol, ul))');
+    first: |-
+      return {result: null, message: 'Testing :first is not yet implemented'};
+    left: |-
+      return {result: null, message: 'Testing :left is not yet implemented'};
+    right: |-
+      return {result: null, message: 'Testing :right is not yet implemented'};
 
 # Features defined here also need to be in custom-js.json.
 javascript:

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -4830,62 +4830,34 @@ css:
     aspect-ratio: |-
       return bcd.testCSSProperty('aspect-ratio', '16 / 9');
   selectors:
-    next-sibling: |-
-      return bcd.testCSSSelector('div + span');
-    child: |-
-      return bcd.testCSSSelector('div > span');
-    column: |-
-      return bcd.testCSSSelector('div || span');
-    subsequent-sibling: |-
-      return bcd.testCSSSelector('div ~ span');
-    cue: |-
-      return bcd.testCSSSelector('video::cue');
-    highlight: |-
-      return bcd.testCSSSelector('::highlight(rainbow-color-1)');
-    part: |-
-      return bcd.testCSSSelector('::part(tab)');
-    slotted: |-
-      return bcd.testCSSSelector('::slotted(*)');
-    view-transition-group: |-
-      return bcd.testCSSSelector('::view-transition-group(*)');
-    view-transition-image-pair: |-
-      return bcd.testCSSSelector('::view-transition-image-pair(*)');
-    view-transition-new: |-
-      return bcd.testCSSSelector('::view-transition-new(*)');
-    view-transition-old: |-
-      return bcd.testCSSSelector('::view-transition-old(*)');
-    active-view-transition: |-
-      return bcd.testCSSSelector(':root:active-view-transition(*)');
-    dir: |-
-      return bcd.testCSSSelector(':dir(ltr)');
-    has: |-
-      return bcd.testCSSSelector(':has(+ *)');
-    host: |-
-      return bcd.testCSSSelector(':host(h1)');
-    host-context: |-
-      return bcd.testCSSSelector(':host-context(h1)');
-    is: |-
-      return bcd.testCSSSelector(':is(h1)');
-    lang: |-
-      return bcd.testCSSSelector(':lang(en-US)');
-    not: |-
-      return bcd.testCSSSelector(':not(strong)');
-    nth-child: |-
-      return bcd.testCSSSelector(':nth-child(even)');
-    nth-last-child: |-
-      return bcd.testCSSSelector(':nth-last-child(even)');
-    nth-last-of-type: |-
-      return bcd.testCSSSelector(':nth-last-of-type(even)');
-    nth-of-type: |-
-      return bcd.testCSSSelector(':nth-of-type(even)');
-    where: |-
-      return bcd.testCSSSelector(':where(ol, ul)');
-    first: |-
-      return {result: null, message: 'Testing :first is not yet implemented'};
-    left: |-
-      return {result: null, message: 'Testing :left is not yet implemented'};
-    right: |-
-      return {result: null, message: 'Testing :right is not yet implemented'};
+    next-sibling: return bcd.testCSSSelector('div + span');
+    child: return bcd.testCSSSelector('div > span');
+    column: return bcd.testCSSSelector('div || span');
+    subsequent-sibling: return bcd.testCSSSelector('div ~ span');
+    cue: return bcd.testCSSSelector('video::cue');
+    highlight: return bcd.testCSSSelector('::highlight(rainbow-color-1)');
+    part: return bcd.testCSSSelector('::part(tab)');
+    slotted: return bcd.testCSSSelector('::slotted(*)');
+    view-transition-group: return bcd.testCSSSelector('::view-transition-group(*)');
+    view-transition-image-pair: return bcd.testCSSSelector('::view-transition-image-pair(*)');
+    view-transition-new: return bcd.testCSSSelector('::view-transition-new(*)');
+    view-transition-old: return bcd.testCSSSelector('::view-transition-old(*)');
+    active-view-transition: return bcd.testCSSSelector(':root:active-view-transition(*)');
+    dir: return bcd.testCSSSelector(':dir(ltr)');
+    has: return bcd.testCSSSelector(':has(+ *)');
+    host: return bcd.testCSSSelector(':host(h1)');
+    host-context: return bcd.testCSSSelector(':host-context(h1)');
+    is: return bcd.testCSSSelector(':is(h1)');
+    lang: return bcd.testCSSSelector(':lang(en-US)');
+    not: return bcd.testCSSSelector(':not(strong)');
+    nth-child: return bcd.testCSSSelector(':nth-child(even)');
+    nth-last-child: return bcd.testCSSSelector(':nth-last-child(even)');
+    nth-last-of-type: return bcd.testCSSSelector(':nth-last-of-type(even)');
+    nth-of-type: return bcd.testCSSSelector(':nth-of-type(even)');
+    where: return bcd.testCSSSelector(':where(ol, ul)');
+    first: "return {result: null, message: 'Testing :first is not yet implemented'};"
+    left: "return {result: null, message: 'Testing :left is not yet implemented'};"
+    right: "return {result: null, message: 'Testing :right is not yet implemented'};"
 
 # Features defined here also need to be in custom-js.json.
 javascript:

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -568,6 +568,22 @@
   }
 
   /**
+   * Test a CSS selector for support
+   *
+   * name (string): The CSS selector name
+   *
+   * returns (TestResult): Whether the selector is supported; if `value` is present,
+   *   whether that value is supported with the selector
+   */
+  function testCSSSelector(name) {
+    // Use CSS.supports if available
+    if ("CSS" in window && window.CSS.supports) {
+      return window.CSS.supports("selector(" + name + ")");
+    }
+    return { result: null, message: "Detection methods are not supported" };
+  }
+
+  /**
    * Test a web assembly feature for support, using the `wasm-feature-detect` Node package
    *
    * feature (string): The web assembly feature name as defined in `wasm-feature-detect`
@@ -1752,6 +1768,7 @@
     testObjectName: testObjectName,
     testOptionParam: testOptionParam,
     testCSSProperty: testCSSProperty,
+    testCSSSelector: testCSSSelector,
     testWasmFeature: testWasmFeature,
     addInstance: addInstance,
     addTest: addTest,

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -570,15 +570,14 @@
   /**
    * Test a CSS selector for support
    *
-   * name (string): The CSS selector name
+   * syntax (string): The CSS selector syntax
    *
-   * returns (TestResult): Whether the selector is supported; if `value` is present,
-   *   whether that value is supported with the selector
+   * returns (TestResult): Whether the selector is supported
    */
-  function testCSSSelector(name) {
+  function testCSSSelector(syntax) {
     // Use CSS.supports if available
     if ("CSS" in window && window.CSS.supports) {
-      return window.CSS.supports("selector(" + name + ")");
+      return window.CSS.supports("selector(" + syntax + ")");
     }
     return { result: null, message: "Detection methods are not supported" };
   }

--- a/test-builder/css.test.ts
+++ b/test-builder/css.test.ts
@@ -22,6 +22,7 @@ describe("build (CSS)", () => {
           url: "",
         },
         properties: [{name: "font-family"}, {name: "font-weight"}],
+        selectors: [],
       },
       "css-grid": {
         spec: {
@@ -29,6 +30,15 @@ describe("build (CSS)", () => {
           url: "",
         },
         properties: [{name: "grid"}],
+        selectors: [],
+      },
+      selectors: {
+        spec: {
+          title: "CSS Selectors Fake",
+          url: "",
+        },
+        properties: [],
+        selectors: [{name: "+"}, {name: "nth-of-type()"}],
       },
     };
 
@@ -73,6 +83,14 @@ describe("build (CSS)", () => {
         code: 'bcd.testCSSProperty("zoom")',
         exposure: ["Window"],
       },
+      "css.selectors.next-sibling": {
+        code: 'bcd.testCSSSelector("+")',
+        exposure: ["Window"],
+      },
+      "css.selectors.nth-of-type": {
+        code: 'bcd.testCSSSelector("nth-of-type()")',
+        exposure: ["Window"],
+      },
     });
   });
 
@@ -84,6 +102,7 @@ describe("build (CSS)", () => {
           url: "",
         },
         properties: [{name: "foo"}],
+        selectors: [],
       },
     };
 
@@ -106,6 +125,7 @@ describe("build (CSS)", () => {
           url: "",
         },
         properties: [{name: "foo"}],
+        selectors: [],
       },
     };
 
@@ -123,6 +143,7 @@ describe("build (CSS)", () => {
           url: "",
         },
         properties: [{name: "bar"}],
+        selectors: [],
       },
     };
 

--- a/test-builder/css.ts
+++ b/test-builder/css.ts
@@ -92,21 +92,21 @@ const build = async (specCSS, customCSS) => {
     }
   }
 
-  for (const name of Array.from(selectors.keys()).sort()) {
-    const bcdName = name
+  for (const selectorSyntax of Array.from(selectors.keys()).sort()) {
+    const bcdName = selectorSyntax
       .replaceAll(":", "")
-      .replace("()", "")
-      .replace("+", "next-sibling")
-      .replace("~", "subsequent-sibling")
-      .replace(">", "child")
-      .replace("&", "nesting")
-      .replace("||", "column");
+      .replaceAll("()", "")
+      .replaceAll("+", "next-sibling")
+      .replaceAll("~", "subsequent-sibling")
+      .replaceAll(">", "child")
+      .replaceAll("&", "nesting")
+      .replaceAll("||", "column");
 
     const ident = `css.selectors.${bcdName}`;
     const customTest = await getCustomTest(ident, "css.selectors", true);
 
     tests[ident] = compileTest({
-      raw: {code: customTest.test || `bcd.testCSSSelector("${name}")`},
+      raw: {code: customTest.test || `bcd.testCSSSelector("${selectorSyntax}")`},
       exposure: ["Window"],
     });
   }

--- a/test-builder/css.ts
+++ b/test-builder/css.ts
@@ -106,7 +106,9 @@ const build = async (specCSS, customCSS) => {
     const customTest = await getCustomTest(ident, "css.selectors", true);
 
     tests[ident] = compileTest({
-      raw: {code: customTest.test || `bcd.testCSSSelector("${selectorSyntax}")`},
+      raw: {
+        code: customTest.test || `bcd.testCSSSelector("${selectorSyntax}")`,
+      },
       exposure: ["Window"],
     });
   }


### PR DESCRIPTION
Attempt to fix https://github.com/openwebdocs/mdn-bcd-collector/issues/828

Running this against Safari 17.2 beta spits out 3 new selectors that look legit and that should be marked supported in BCD:

- css/selectors/fullscreen.json
- css/selectors/highlight.json
- css/selectors/picture-in-picture.json
- and it also finds `has()` support in Firefox 121.

I know that testing support using the `CSS.supports('selector(FOO)');` syntax has not been supported since the start, but I think this still gets us somewhere. https://developer.mozilla.org/en-US/docs/Web/CSS/@supports#browser_compatibility