### PR TITLE
Collect events

### DIFF
--- a/scripts/find-missing-features.ts
+++ b/scripts/find-missing-features.ts
@@ -29,7 +29,7 @@ const traverseFeatures = (obj: any, path: string, includeAliases?: boolean) => {
     if (compat) {
       features.push(`${path}${id}`);
 
-      if (includeAliases && !id.endsWith("_event")) {
+      if (includeAliases) {
         const aliases = new Set();
         for (let statements of Object.values(compat.support)) {
           if (!Array.isArray(statements)) {

--- a/test-builder/api.test.ts
+++ b/test-builder/api.test.ts
@@ -469,6 +469,10 @@ describe("build (API)", () => {
           code: '"Foo" in self',
           exposure: ["Window"],
         },
+        "api.Foo.add_event": {
+          code: '"Foo" in self && "onadd" in Foo.prototype',
+          exposure: ["Window"],
+        },
       });
     });
 

--- a/test-builder/api.ts
+++ b/test-builder/api.ts
@@ -76,10 +76,15 @@ const flattenIDL = (specIDLs: IDLFiles, customIDLs: IDLFiles) => {
   // mix in the mixins
   for (const dfn of ast) {
     if (dfn.type === "includes") {
-      if (dfn.includes === "WindowOrWorkerGlobalScope") {
-        // WindowOrWorkerGlobalScope is mapped differently in BCD
+      const skipIncludes = [
+        "WindowOrWorkerGlobalScope", // handled separately as globals
+        "GlobalEventHandlers", // XXX needs special handling
+        "WindowEventHandlers", // XXX needs special handling
+      ];
+      if (skipIncludes.includes(dfn.includes)) {
         continue;
       }
+
       const mixin = ast.find(
         (it) =>
           !("partial" in it && it.partial) &&
@@ -152,7 +157,10 @@ const flattenMembers = (iface) => {
             ["clientInformation", "pageXOffset", "pageYOffset"].includes(
               member.name,
             )) ||
-          (iface.name === "Element" && member.name === "webkitMatchesSelector")
+          (iface.name === "Element" &&
+            member.name === "webkitMatchesSelector") ||
+          (iface.name === "Serial" &&
+            ["onconnect", "ondisconnect"].includes(member.name))
         ),
     );
   for (const member of iface.members.filter((member) => !member.name)) {
@@ -441,30 +449,27 @@ const buildIDLMemberTests = async (
 
   for (const member of members) {
     const isStatic = member.special === "static" || iface.type === "namespace";
-    const name = member.name + (isStatic ? "_static" : "");
-
-    if (handledMemberNames.has(name)) {
-      continue;
-    }
+    let name = member.name + (isStatic ? "_static" : "");
 
     const isEventHandler =
       member.idlType?.type === "attribute-type" &&
       typeof member.idlType?.idlType === "string" &&
       member.idlType?.idlType.endsWith("EventHandler");
 
-    if (isEventHandler) {
-      // XXX Tests for events will be added with another package, see
-      // https://github.com/openwebdocs/mdn-bcd-collector/issues/133 for
-      // details. In the meantime, ignore event handlers.
+    name = isEventHandler ? `${member.name.replace(/^on/, "")}_event` : name;
+
+    if (handledMemberNames.has(name)) {
       continue;
     }
 
     let expr: string | RawTestCodeExpr | RawTestCodeExpr[] = "";
 
-    // Constructors, constants, and static attributes should not have
+    // Constructors, constants, event handlers and static attributes should not have
     // auto-generated custom tests
     const customTestExactMatchNeeded =
-      isStatic || ["toString", "toJSON"].includes(member.name as string);
+      isStatic ||
+      isEventHandler ||
+      ["toString", "toJSON"].includes(member.name as string);
 
     const customTestMember = await getCustomTest(
       `${settings.path}.${name}`,
@@ -529,10 +534,6 @@ const buildIDLMemberTests = async (
           break;
       }
     }
-
-    // const name = isEventHandler
-    //   ? `${member.name.replace(/^on/, '')}_event`
-    //   : member.name;
 
     tests[name] = compileTest({
       raw: {

--- a/test-builder/api.ts
+++ b/test-builder/api.ts
@@ -449,14 +449,14 @@ const buildIDLMemberTests = async (
 
   for (const member of members) {
     const isStatic = member.special === "static" || iface.type === "namespace";
-    let name = member.name + (isStatic ? "_static" : "");
-
     const isEventHandler =
       member.idlType?.type === "attribute-type" &&
       typeof member.idlType?.idlType === "string" &&
       member.idlType?.idlType.endsWith("EventHandler");
 
-    name = isEventHandler ? `${member.name.replace(/^on/, "")}_event` : name;
+    const name = isEventHandler
+      ? `${member.name.replace(/^on/, "")}_event`
+      : member.name + (isStatic ? "_static" : "");
 
     if (handledMemberNames.has(name)) {
       continue;

--- a/test-builder/api.ts
+++ b/test-builder/api.ts
@@ -464,12 +464,10 @@ const buildIDLMemberTests = async (
 
     let expr: string | RawTestCodeExpr | RawTestCodeExpr[] = "";
 
-    // Constructors, constants, event handlers and static attributes should not have
+    // Constructors, constants, and static attributes should not have
     // auto-generated custom tests
     const customTestExactMatchNeeded =
-      isStatic ||
-      isEventHandler ||
-      ["toString", "toJSON"].includes(member.name as string);
+      isStatic || ["toString", "toJSON"].includes(member.name as string);
 
     const customTestMember = await getCustomTest(
       `${settings.path}.${name}`,

--- a/test-builder/common.ts
+++ b/test-builder/common.ts
@@ -133,7 +133,8 @@ const generateCustomTestCode = async (
       return false;
     }
 
-    const member = parts.length > 1 ? parts[1] : "";
+    const member =
+      parts.length > 1 ? parts[1].replace(/(\w+)_event/, "on$1") : "";
 
     if (member === parts[0]) {
       // Constructors must have an exact test match


### PR DESCRIPTION
Unfortunately, I see no more context for https://github.com/openwebdocs/mdn-bcd-collector/commit/8f23515e8d203b878178bb8f9bc874f3235bfccf. There was no pull request...

I'm suggesting to add event collections back but ignore everything that has to do with GlobalEventHandlers and WindowEventHandlers for now.

(Also, I know Serial events can be ignored due to bubbling to SerialPort. Added that exception in as well.)