### PR TITLE
Add more ctor error messages

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -261,7 +261,14 @@
           "requires a single argument",
           "requires at least",
           "first argument",
-          "expects exactly"
+          "First argument",
+          "expects exactly",
+          "Invalid argument type",
+          "invalid_argument",
+          "target",
+          "Promise resolver undefined",
+          "type must not be undefined",
+          "must be callable"
         ])
       ) {
         // If it failed to construct and it's not illegal or just needs


### PR DESCRIPTION
These constructors currently report unknown support in Safari and Chrome because their error messages are not in the list. They surely are supported.

  - javascript.builtins.BigInt.BigInt
   - javascript.builtins.FinalizationRegistry.FinalizationRegistry
   - javascript.builtins.Intl.DisplayNames.DisplayNames
   - javascript.builtins.Intl.Locale.Locale
   - javascript.builtins.Promise.Promise
   - javascript.builtins.Proxy.Proxy
   - javascript.builtins.WeakRef.WeakRef