### PR TITLE
Collect Selenium results for beta browsers

### DIFF
--- a/lib/filter-versions.ts
+++ b/lib/filter-versions.ts
@@ -37,7 +37,7 @@ const filterVersions = (
 
   const releases = Object.entries(
     (bcdBrowsers[browser] as BrowserStatement).releases,
-  ).filter(([, r]) => ["current", "retired"].includes(r.status));
+  ).filter(([, r]) => ["current", "beta", "retired"].includes(r.status));
 
   for (const [version, versionData] of releases) {
     if (typeof since === "string") {


### PR DESCRIPTION
I've been manually collecting results on beta browsers but ideally we want to collect results automatically. I think this PR should do that.
This will help to reduce manual BCD PRs that people usually submit during the beta phase of browsers. See also https://github.com/mdn/community-meetings/blob/main/23-12-11/minutes.md#bcd where Ruth asked about this.