### PR TITLE
Fix Selenium action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,10 @@ jobs:
           path: mdn-bcd-results
       - name: Run Selenium and collect results
         if: steps.check.outputs.changed == 'true'
-        run: RESULTS_DIR=mdn-bcd-results npm run selenium
+        run: |
+           npm install -D typescript
+           npm install -D ts-node
+           RESULTS_DIR=mdn-bcd-results npm run selenium
       - name: Submit all results to results repo
         if: steps.check.outputs.changed == 'true'
         uses: dmnemec/copy_file_to_another_repo_action@main


### PR DESCRIPTION
The deployment failed because the new selenium action wasn't running properly. https://github.com/openwebdocs/mdn-bcd-collector/actions/runs/7210067042/job/19642407956

https://github.com/openwebdocs/mdn-bcd-results is empty now

Maybe this fixes it? @queengooborg 