### PR TITLE
Don't set NODE_ENV=production in start command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:tests": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning test-builder/index.ts",
     "build:resources": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning prepare-resources.ts",
     "gcp-build": "npm run build",
-    "start": "NODE_ENV=production node app.js",
+    "start": "node app.js",
     "dev": "npm i && npm run build:tests && npm run build:resources && nf -j Procfile.dev start",
     "unittest": "NODE_ENV=test c8 mocha --recursive './**/*.test.ts'",
     "coverage": "npm run coverage:report && npm run coverage:open",


### PR DESCRIPTION
This variable is now set as a configuration variable in the Heroku deployment.
