### PR TITLE
Provide better tests for SVG attributes

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -5188,6 +5188,91 @@ javascript:
             return {result: false, message: e.message};
           }
 
+svg:
+  elements:
+    a:
+      xlink_actuate: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:actuate', 'onRequest');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'actuate') === 'onRequest';
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+      xlink_show: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:show', 'new');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'show') === 'new';
+      xlink_title: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:show', 'newTitle');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'show') === 'newTitle';
+    cursor:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'cursor');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    feImage:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feImage');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    filter:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'filter');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    font-face-uri:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-uri');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    glyphRef:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'glyphRef');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    image:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    linearGradient:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    mpath:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mpath');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    pattern:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'pattern');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    radialGradient:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    script:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'script');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    textPath:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'textPath');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+    use:
+      xlink_href: |-
+        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'use');
+        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
+
 # Features defined here also need to be in test-builder/webassembly.ts.
 webassembly:
   # Features defined here also need to be in https://webassembly.github.io/spec/web-api/index.html or custom/idl/webassembly.idl.

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -5195,10 +5195,6 @@ svg:
         var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
         instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:actuate', 'onRequest');
         return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'actuate') === 'onRequest';
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
       xlink_show: |-
         var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
         instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:show', 'new');
@@ -5207,71 +5203,6 @@ svg:
         var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
         instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:show', 'newTitle');
         return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'show') === 'newTitle';
-    cursor:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'cursor');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    feImage:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'feImage');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    filter:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'filter');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    font-face-uri:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'font-face-uri');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    glyphRef:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'glyphRef');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    image:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'image');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    linearGradient:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'linearGradient');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    mpath:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'mpath');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    pattern:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'pattern');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    radialGradient:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'radialGradient');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    script:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'script');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    textPath:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'textPath');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
-    use:
-      xlink_href: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'use');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test';
 
 # Features defined here also need to be in test-builder/webassembly.ts.
 webassembly:

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -5188,22 +5188,6 @@ javascript:
             return {result: false, message: e.message};
           }
 
-svg:
-  elements:
-    a:
-      xlink_actuate: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:actuate', 'onRequest');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'actuate') === 'onRequest';
-      xlink_show: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:show', 'new');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'show') === 'new';
-      xlink_title: |-
-        var instance = document.createElementNS('http://www.w3.org/2000/svg', 'a');
-        instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:show', 'newTitle');
-        return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'show') === 'newTitle';
-
 # Features defined here also need to be in test-builder/webassembly.ts.
 webassembly:
   # Features defined here also need to be in https://webassembly.github.io/spec/web-api/index.html or custom/idl/webassembly.idl.

--- a/test-builder/elements.ts
+++ b/test-builder/elements.ts
@@ -124,7 +124,10 @@ const build = async (specElements, customElements) => {
             ].reduce((acc, cv) => ({...acc, ...cv}), {})
           : data.attributes;
 
-        for (const [attrName, attrProp] of Object.entries(attributes)) {
+        for (const [attrName, attrProp] of Object.entries(attributes) as [
+          string,
+          string,
+        ][]) {
           const customAttrTest = await getCustomTest(
             `${bcdPath}.${attrName}`,
             "${category}.elements",

--- a/test-builder/elements.ts
+++ b/test-builder/elements.ts
@@ -161,10 +161,10 @@ const build = async (specElements, customElements) => {
             if (attrProp.startsWith("xlink_")) {
               const xlinkAttr = attrProp.replace("xlink_", "");
               attrCode = `(function() {
-                var instance = ${defaultConstructCode};
-                instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:${xlinkAttr}', 'test');
-                return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', '${xlinkAttr}') === 'test'
-              })()`;
+  var instance = ${defaultConstructCode};
+  instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:${xlinkAttr}', 'test');
+  return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', '${xlinkAttr}') === 'test';
+})()`;
             }
           }
 

--- a/test-builder/elements.ts
+++ b/test-builder/elements.ts
@@ -136,21 +136,38 @@ const build = async (specElements, customElements) => {
             return !!instance && '${attrProp}' in instance;
           })()`;
 
-          // All SVG "in" attributes are reflected as "in1" in SVGOM
-          if (attrProp === "in") {
-            attrCode = `(function() {
-              var instance = ${defaultConstructCode};
-              return !!instance && 'in1' in instance;
-            })()`;
-          }
-
-          // All xlink:href attributes need special handling
-          if (attrProp === "xlink_href") {
-            attrCode = `(function() {
-              var instance = ${defaultConstructCode};
-              instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-              return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test'
-            })()`;
+          // SVG attributes need some tweaks
+          if (category === "svg") {
+            // Certain SVG attributes are reflected differently in SVGOM
+            if (attrProp === "in") {
+              attrCode = attrCode.replace("'in'", "'in1'");
+            }
+            if (attrProp === "kernelUnitLength") {
+              attrCode = attrCode.replace(
+                "kernelUnitLength",
+                "kernelUnitLengthX",
+              );
+            }
+            if (attrProp === "order") {
+              attrCode = attrCode.replace("order", "orderX");
+            }
+            if (attrProp === "stdDeviation") {
+              attrCode = attrCode.replace("stdDeviation", "stdDeviationX");
+            }
+            if (attrProp === "radius") {
+              attrCode = attrCode.replace("radius", "radiusX");
+            }
+            if (attrProp === "baseFrequency") {
+              attrCode = attrCode.replace("baseFrequency", "baseFrequencyX");
+            }
+            // All xlink:href attributes need special handling
+            if (attrProp === "xlink_href") {
+              attrCode = `(function() {
+                var instance = ${defaultConstructCode};
+                instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+                return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test'
+              })()`;
+            }
           }
 
           tests[`${bcdPath}.${attrName}`] = compileTest({

--- a/test-builder/elements.ts
+++ b/test-builder/elements.ts
@@ -131,14 +131,31 @@ const build = async (specElements, customElements) => {
             true,
           );
 
-          const defaultAttrCode = `(function() {
-    var instance = ${defaultConstructCode};
-    return !!instance && '${attrProp}' in instance;
-  })()`;
+          let attrCode = `(function() {
+            var instance = ${defaultConstructCode};
+            return !!instance && '${attrProp}' in instance;
+          })()`;
+
+          // All SVG "in" attributes are reflected as "in1" in SVGOM
+          if (attrProp === "in") {
+            attrCode = `(function() {
+              var instance = ${defaultConstructCode};
+              return !!instance && 'in1' in instance;
+            })()`;
+          }
+
+          // All xlink:href attributes need special handling
+          if (attrProp === "xlink_href") {
+            attrCode = `(function() {
+              var instance = ${defaultConstructCode};
+              instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
+              return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test'
+            })()`;
+          }
 
           tests[`${bcdPath}.${attrName}`] = compileTest({
             raw: {
-              code: customAttrTest.test || defaultAttrCode,
+              code: customAttrTest.test || attrCode,
             },
             exposure: ["Window"],
           });

--- a/test-builder/elements.ts
+++ b/test-builder/elements.ts
@@ -136,36 +136,31 @@ const build = async (specElements, customElements) => {
             return !!instance && '${attrProp}' in instance;
           })()`;
 
-          // SVG attributes need some tweaks
+          // Some SVG attribute names are reflected differently in SVGOM
           if (category === "svg") {
-            // Certain SVG attributes are reflected differently in SVGOM
-            if (attrProp === "in") {
-              attrCode = attrCode.replace("'in'", "'in1'");
-            }
-            if (attrProp === "kernelUnitLength") {
+            const replacements = {
+              baseFrequency: "baseFrequencyX",
+              in: "in1",
+              kernelUnitLength: "kernelUnitLengthX",
+              order: "orderX",
+              radius: "radiusX",
+              stdDeviation: "stdDeviationX",
+            };
+
+            if (attrProp in replacements) {
               attrCode = attrCode.replace(
-                "kernelUnitLength",
-                "kernelUnitLengthX",
+                `'${attrProp}'`,
+                `'${replacements[attrProp]}'`,
               );
             }
-            if (attrProp === "order") {
-              attrCode = attrCode.replace("order", "orderX");
-            }
-            if (attrProp === "stdDeviation") {
-              attrCode = attrCode.replace("stdDeviation", "stdDeviationX");
-            }
-            if (attrProp === "radius") {
-              attrCode = attrCode.replace("radius", "radiusX");
-            }
-            if (attrProp === "baseFrequency") {
-              attrCode = attrCode.replace("baseFrequency", "baseFrequencyX");
-            }
-            // All xlink:href attributes need special handling
-            if (attrProp === "xlink_href") {
+
+            // All xlink attributes need special handling
+            if (attrProp.startsWith("xlink_")) {
+              const xlinkAttr = attrProp.replace("xlink_", "");
               attrCode = `(function() {
                 var instance = ${defaultConstructCode};
-                instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', 'test');
-                return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', 'href') === 'test'
+                instance.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:${xlinkAttr}', 'test');
+                return !!instance && instance.getAttributeNS('http://www.w3.org/1999/xlink', '${xlinkAttr}') === 'test'
               })()`;
             }
           }


### PR DESCRIPTION
This PR fixes some SVG attribute tests:

- All xlink_href, xlink_actuate, xlink_show, and xlink_title tests need special handling and so I updated the element test builder. They are used on many SVG elements.
- Several attributes have different names in the SVGOM. I did some replacements in the test builder as they appear many times on various SVG elements as well.
