### PR TITLE
Add custom rule for `plus-darker`in mix-blend-mode

### DIFF
--- a/custom/css.json
+++ b/custom/css.json
@@ -762,7 +762,7 @@
     },
     "min-zoom": {},
     "mix-blend-mode": {
-      "__values": ["plus-lighter"]
+      "__values": ["plus-darker", "plus-lighter"]
     },
     "motion": {},
     "motion-distance": {},


### PR DESCRIPTION
`plus-darker` has been added to the spec at the same time as `plus-lighter`, it should have a specific bcd entry (as soon as it is implemented)