### PR TITLE
Add ArrayBuffer.transfer

### DIFF
--- a/custom/js.json
+++ b/custom/js.json
@@ -11,6 +11,11 @@
         "instance": ["group", "groupToMap", "length"]
       }
     },
+    "ArrayBuffer": {
+      "members": {
+        "instance": ["transfer"]
+      }
+    },
     "Error": {
       "members": {
         "instance": ["cause", "columnNumber", "fileName", "lineNumber", "stack"]


### PR DESCRIPTION
Not picked up automatically because we're not scraping all ECMAScript specs, see https://github.com/openwebdocs/mdn-bcd-collector/issues/893

Ships in Firefox 122 and we should detect it!