### PR TITLE
Makes output arg for feature-list.json more explicitly optional

### DIFF
--- a/scripts/add-new-bcd.ts
+++ b/scripts/add-new-bcd.ts
@@ -235,7 +235,6 @@ const main = async (): Promise<void> => {
     {addNewFeatures: true},
     bcd.browsers,
     overrides,
-    "",
   );
 
   console.log("Injecting BCD...");

--- a/scripts/update-bcd.ts
+++ b/scripts/update-bcd.ts
@@ -1300,7 +1300,7 @@ export const main = async (
   filter: any,
   browsers: Browsers,
   overrides: Overrides,
-  outputPath: string,
+  outputPath?: string,
 ): Promise<void> => {
   // Replace filter.path with a minimatch object.
   if (filter.path && filter.path.includes("*")) {
@@ -1350,7 +1350,7 @@ export const main = async (
     await fs.writeFile(file, json);
   }
 
-  if (featureList.length) {
+  if (featureList.length && outputPath) {
     const featureListJSON = JSON.stringify(featureList, null, "  ") + "\n";
     await fs.writeFile(outputPath, featureListJSON);
   }


### PR DESCRIPTION
Quick fix for a bug that @Elchi3 caught in a [related PR](https://github.com/openwebdocs/mdn-bcd-collector/pull/947#discussion_r1431449823) that added the ability for the update script to output a list of updated features. 