### PR TITLE
Add detached/transferToFixed to ArrayBuffer

### DIFF
--- a/custom/js.json
+++ b/custom/js.json
@@ -13,7 +13,7 @@
     },
     "ArrayBuffer": {
       "members": {
-        "instance": ["transfer"]
+        "instance": ["detached", "transfer", "transferToFixed"]
       }
     },
     "Error": {


### PR DESCRIPTION
Follow up to https://github.com/openwebdocs/mdn-bcd-collector/pull/994. I didn't read the spec but should have. There is more than just the transfer method.

Can be avoided if we would solve https://github.com/openwebdocs/mdn-bcd-collector/issues/893 to get this from the draft specs somehow.