### PR TITLE
Add non-standard Mozilla Directory.idl

### DIFF
--- a/custom/idl/Directory.idl
+++ b/custom/idl/Directory.idl
@@ -1,3 +1,5 @@
+// https://searchfox.org/mozilla-central/source/dom/webidl/Directory.webidl
+
 [Exposed=(Window,Worker)]
 interface Directory {
   [Throws]

--- a/custom/idl/Directory.idl
+++ b/custom/idl/Directory.idl
@@ -1,0 +1,17 @@
+[Exposed=(Window,Worker)]
+interface Directory {
+  [Throws]
+  readonly attribute DOMString name;
+};
+
+[Exposed=(Window,Worker)]
+partial interface Directory {
+  [Throws]
+  readonly attribute DOMString path;
+
+  [NewObject]
+  Promise<sequence<(File or Directory)>> getFilesAndDirectories();
+
+  [NewObject]
+  Promise<sequence<File>> getFiles(optional boolean recursiveFlag = false);
+};


### PR DESCRIPTION
Source: https://searchfox.org/mozilla-central/source/dom/webidl/Directory.webidl

I expurged the IDL from chrome-only features unavailable on the web and comments.