### PR TITLE
Add custom IDL for HTMLMediaElement.allowedToPlay

### DIFF
--- a/custom/idl/html.idl
+++ b/custom/idl/html.idl
@@ -262,3 +262,9 @@ partial interface WorkerGlobalScope {
   // https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/dump
   undefined dump(any... data);
 };
+
+// Non-standard addition in Gecko
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1478208
+partial interface HTMLMediaElement {
+  readonly attribute boolean allowedToPlay;
+};


### PR DESCRIPTION
This was added in Firefox 63 and we have a mention of it in mdn/content: https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide

So this is likely something we will document in the future.