### PR TITLE
Add proposed HTMLAnchorElement.hrefTranslate

### DIFF
--- a/custom/idl/html.idl
+++ b/custom/idl/html.idl
@@ -264,3 +264,10 @@ partial interface WorkerGlobalScope {
 partial interface HTMLMediaElement {
   readonly attribute boolean allowedToPlay;
 };
+
+// Proposed addition to HTML (implemented in Chrome)
+// https://github.com/whatwg/html/pull/3870
+// https://github.com/mdn/browser-compat-data/issues/21898
+partial interface HTMLAnchorElement {
+  [CEReactions]attribute DOMString hrefTranslate;
+};


### PR DESCRIPTION
This is a first step in fixing https://github.com/mdn/browser-compat-data/issues/21898 (the property is implemented in Chrome)