### PR TITLE
Remove api.File.type

### DIFF
--- a/custom/idl/FileAPI.idl
+++ b/custom/idl/FileAPI.idl
@@ -1,6 +1,5 @@
 partial interface File {
   readonly attribute object lastModifiedDate;
-  readonly attribute DOMString type;
 };
 
 partial interface FileSystemHandle {


### PR DESCRIPTION
The File interface inherits from Blob, which is where the attribute is defined.  No need to define it again.
