### PR TITLE
Ignore CSS types from Webref (and prepare for when we want them)

### DIFF
--- a/test-builder/css.test.ts
+++ b/test-builder/css.test.ts
@@ -27,7 +27,7 @@ describe("build (CSS)", () => {
           {name: "font-family"},
           {
             name: "font-weight",
-            values: [{name: "normal", value: "normal"}],
+            values: [{name: "normal", value: "normal", type: "value"}],
           },
         ],
         selectors: [],


### PR DESCRIPTION
This is a quick follow-up to #1033 to do two things:

- Ignore any values that contain a CSS type within them
- Add remapping capabilities to handle these types if/when we want to
