### PR TITLE
deploy.yml: Remove old results; fix secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,9 +44,10 @@ jobs:
       - name: Run Selenium and collect results
         if: steps.check.outputs.changed == 'true'
         run: |
-           npm install -D typescript
-           npm install -D ts-node
-           RESULTS_DIR=mdn-bcd-results SECRETS_JSON="${{secrets.SECRETS_JSON}}" npm run selenium
+          npm install -D typescript
+          npm install -D ts-node
+          rm mdn-bcd-results/*.json
+          RESULTS_DIR=mdn-bcd-results SECRETS_JSON="${{secrets.SECRETS_JSON}}" npm run selenium
       - name: Submit all results to results repo
         if: steps.check.outputs.changed == 'true'
         uses: dmnemec/copy_file_to_another_repo_action@main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,9 @@ jobs:
         run: |
           npm install -D typescript
           npm install -D ts-node
+          echo "${{secrets.SECRETS_JSON}}" > secrets.json
           rm mdn-bcd-results/*.json
-          RESULTS_DIR=mdn-bcd-results SECRETS_JSON="${{secrets.SECRETS_JSON}}" npm run selenium
+          RESULTS_DIR=mdn-bcd-results npm run selenium
       - name: Submit all results to results repo
         if: steps.check.outputs.changed == 'true'
         uses: dmnemec/copy_file_to_another_repo_action@main


### PR DESCRIPTION
I'd always remove old results when a new version of the collector is released.  It turns out, with the overhauled update-bcd script, this is now much more important.

This also fixes the secrets by putting them into a file rather than just environment variables.