### PR TITLE
Improve find-missing-features statistics output

### DIFF
--- a/scripts/find-missing-features.ts
+++ b/scripts/find-missing-features.ts
@@ -112,7 +112,7 @@ const getMissing = (
   direction: string,
   pathFilter: string[] = [],
   includeAliases = false,
-): {[path: string]: {missing: string[]; all: string[]}} => {
+): Record<string, {missing: string[]; all: string[]}> => {
   const bcdEntries = traverseFeatures(bcd, "", includeAliases);
   const collectorEntries = Object.keys(tests).filter(
     (p) => p !== "__resources",


### PR DESCRIPTION
This PR performs two updates to improve the `find-missing-features` script statistics:

- Adds a `-c/--count-only` option, which will only print the counts, suppressing the list of missing features
- Prints the statistics for each individual path filter (ex. `-p api -p css` will now list statistics for `api` and `css` individually as well as together)

<img width="1137" alt="image" src="https://github.com/openwebdocs/mdn-bcd-collector/assets/5179191/d919b9a2-df00-4d24-973e-22f2731e48f5">
