### PR TITLE
Add bcd.skipIf() function

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -2255,13 +2255,14 @@ api:
             return instance.getContext('2d', options);
           }
           return bcd.testOptionParam(createContext, null, 'willReadFrequently', true);
-        # XXX Crashes Safari 16.5
-        # webgpu_context: |-
-        #   if (!(instance && instance.getContext)) {
-        #     return {result: false, message: 'instance.getContext is not defined'};
-        #   }
-        #   var ctx = instance.getContext('webgpu');
-        #   return !!ctx;
+        webgpu_context: |-
+          bcd.skipIf('safari', '16.5', 'Creating a WebGPU context on Safari 16.5 crashes the browser');
+
+          if (!(instance && instance.getContext)) {
+            return {result: false, message: 'instance.getContext is not defined'};
+          }
+          var ctx = instance.getContext('webgpu');
+          return !!ctx;
   HTMLCollection:
     __base: var instance = document.forms;
   HTMLContentElement:
@@ -3918,6 +3919,8 @@ api:
       var instance = reusableInstances.audioContext.createScriptProcessor();
   SecurityPolicyViolationEvent:
     __base: |-
+      bcd.skipIf('edge', '15', 'Constructing this event causes the page to reload');
+
       if (!('SecurityPolicyViolationEvent' in self)) {
         return {result: false, message: 'SecurityPolicyViolationEvent is not defined'};
       }

--- a/scripts/selenium.ts
+++ b/scripts/selenium.ts
@@ -88,7 +88,7 @@ const ignore = {
     12: gumTests,
     13: gumTests,
     14: gumTests,
-    15: ["api.SecurityPolicyViolationEvent", ...gumTests],
+    15: gumTests,
     16: gumTests,
     17: gumTests,
     18: gumTests,

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -36,6 +36,10 @@
     __sources: {}
   };
   var cleanupFunctions = [];
+  var browser = {
+    name: "",
+    version: ""
+  };
 
   // Set to true for debugging output, and 'full' to include completion logging
   var debugmode =
@@ -199,6 +203,33 @@
    */
   function addCleanup(f) {
     cleanupFunctions.push(f);
+  }
+
+  /**
+   * Skips the test by throwing an error if the browser (and possibly version) matches
+   * Avoid using this if possible
+   * @param {string} browserName - The name of the browser to skip
+   * @param {string?} browserVersion - The browser version to skip, if needed
+   * @param {string?} reason - The reason for skipping
+   */
+  function skipIf(browserName, browserVersion, reason) {
+    if (!browserName) {
+      return;
+    }
+
+    if (browserName !== browser.name) {
+      return;
+    }
+
+    if (browserVersion) {
+      if (browserVersion !== browser.version) {
+        return;
+      }
+    }
+
+    throw new Error(
+      "Test skipped on this browser: " + (reason || "no reason provided")
+    );
   }
 
   /**
@@ -1370,9 +1401,15 @@
    * @param {((results: TestResults) => void)?} onComplete - The callback to call once tests are completed
    * @param {number?} resourceCount - The number of resources required
    * @param {boolean} hideResults - Whether to keep the results hidden afterwards
+   * @param {{name: string, version: string}} browserInfo - The info of the current browser
    * @callback TestResults - The processed result of the tests
    */
-  function go(onComplete, resourceCount, hideResults) {
+  function go(onComplete, resourceCount, hideResults, browserInfo) {
+    if (browserInfo) {
+      browser.name = browserInfo.name;
+      browser.version = browserInfo.version;
+    }
+
     loadResources(function () {
       doTests(onComplete, hideResults);
     }, resourceCount);
@@ -1802,6 +1839,7 @@
     addInstance: addInstance,
     addTest: addTest,
     addCleanup: addCleanup,
+    skipIf: skipIf,
     runTests: runTests,
     go: go
   };

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -69,6 +69,14 @@ See the LICENSE file for copyright details
     bcd.addTest("<%- test.ident %>", <%- JSON.stringify(test.tests) %>, "<%- test.exposure %>");
   <% }); %>
   window.onload = function() {
-    bcd.go(undefined, <%- resourcesToLoad.size %>, <%- !!selenium %>)
+    bcd.go(
+      undefined,
+      <%- resourcesToLoad.size %>,
+      <%- !!selenium %>,
+      {
+        "name": "<%- browser.browser.id %>",
+        "version": "<%- browser.version %>"
+      }
+    )
   };
 </script>


### PR DESCRIPTION
This PR adds a `skipIf()` function, which will skip the test if the browser and browser version (optional) match.  This is for rare cases when a test will cause a crash in a certain browser.
