### PR TITLE
Allow URL tests to run in non-browser runtimes

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -4005,23 +4005,23 @@ api:
       if (!('Request' in self)) {
         return {result: false, message: 'Request is not defined'};
       }
-      var instance = new Request('');
+      var instance = new Request('http://example.com');
     Request:
       __additional:
         init_priority_parameter: |-
           function construct(options) {
-            new Request('', options);
+            new Request('http://example.com', options);
           }
           return bcd.testOptionParam(construct, null, 'priority', 'auto');
         init_referrer_parameter: |-
           function construct(options) {
-            new Request('', options);
+            new Request('http://example.com', options);
           }
           return bcd.testOptionParam(construct, null, 'referrer', 'no-referrer');
     cache:
       __additional:
         only-if-cached: |-
-          instance = new Request('/favicon/favicon.ico', {mode: "same-origin", cache: "only-if-cached"});
+          instance = new Request('http://example.com/favicon/favicon.ico', {mode: "same-origin", cache: "only-if-cached"});
           return instance.cache === "only-if-cached";
     credentials:
       __additional:
@@ -5284,9 +5284,9 @@ api:
     __base: |-
       var instance;
       try {
-        instance = new URL(location.href)
+        instance = new URL('http://example.com')
       } catch(e) {
-        instance = new webkitURL(location.href)
+        instance = new webkitURL('http://example.com')
       };
     __test: return 'URL' in self;
   URLPattern:


### PR DESCRIPTION
Hi! I'm working on [runtime-compat](https://github.com/unjs/runtime-compat), which is a new project to collect some of the same data as BCD, but for non-browser JS runtimes. You can see its current state here: https://runtime-compat.unjs.io/ We've been using your tests from this project to track web API coverage, which are great for most purposes (thanks!). However there are a few cases where we're getting false failures because of implementation details in the tests. I hope you're OK with me contributing a small fix that will allow these tests to run outside the browser.
I've opened this PR to work around one of the main problems. All of the runtimes that we're testing support `URL`, however they don't set `location.href`. The URL and Request tests are showing as failures for all of these features, even though they are supported, because the tests either use an empty string, a relative URL or `location.href`, none of which work outside the browser. In this PR I've replaced the empty string and `location.href` with `http://example.com`. This shouldn't affect the tests for browsers, but will allow our tested runtimes to run the tests correctly.
Let me know if you have any questions, or if you'd like to join our Discord where we're organising this. Thanks!