### PR TITLE
Add custom IDL for WebRTC extensions

### DIFF
--- a/custom/idl/webrtc-extensions.idl
+++ b/custom/idl/webrtc-extensions.idl
@@ -1,0 +1,83 @@
+// Anything that's shipping from https://w3c.github.io/webrtc-extensions/
+// See https://github.com/w3c/browser-specs/issues/305 for including this in browser-specs.
+
+partial dictionary RTCRtpHeaderExtensionCapability {
+  required RTCRtpTransceiverDirection direction;
+};
+
+partial interface RTCRtpTransceiver {
+  sequence<RTCRtpHeaderExtensionCapability> getHeaderExtensionsToNegotiate();
+  undefined setHeaderExtensionsToNegotiate(
+      sequence<RTCRtpHeaderExtensionCapability> extensions);
+  sequence<RTCRtpHeaderExtensionCapability> getNegotiatedHeaderExtensions();
+};
+
+partial interface RTCRtpReceiver {
+  attribute DOMHighResTimeStamp? jitterBufferTarget;
+};
+
+partial dictionary RTCRtpEncodingParameters {
+  unsigned long ptime;
+  boolean adaptivePtime = false;
+  RTCRtpCodec codec;
+};
+
+partial dictionary RTCSetParameterOptions {
+  sequence<RTCEncodingOptions> encodingOptions = [];
+};
+
+dictionary RTCEncodingOptions {
+  boolean keyFrame = false;
+};
+
+partial interface RTCIceTransport {
+  attribute EventHandler onicecandidatepairadd;
+  attribute EventHandler onicecandidatepairremove;
+  attribute EventHandler onicecandidatepairnominate;
+  // RTCIceCandidatePair changed to object to pass Web IDL validation.
+  // See https://github.com/w3c/webrtc-pc/pull/2951.
+  Promise<undefined> selectCandidatePair(object candidatePair);
+  Promise<undefined> removeCandidatePair(object candidatePair);
+};
+
+[Exposed=Window]
+interface RTCIceCandidatePairEvent : Event {
+  constructor(DOMString type, RTCIceCandidatePairEventInit eventInitDict);
+  readonly attribute RTCIceCandidate local;
+  readonly attribute RTCIceCandidate remote;
+};
+
+dictionary RTCIceCandidatePairEventInit : EventInit {
+  required RTCIceCandidate local;
+  required RTCIceCandidate remote;
+};
+
+partial dictionary RTCRtpContributingSource {
+  DOMHighResTimeStamp captureTimestamp;
+  DOMHighResTimeStamp senderCaptureTimeOffset;
+};
+
+[Exposed=(Window,Worker), Transferable]
+partial interface RTCDataChannel {
+};
+
+enum RTCRtpHeaderEncryptionPolicy {
+  "negotiate",
+  "require"
+};
+
+partial interface RTCRtpTransceiver {
+  readonly attribute boolean rtpHeaderEncryptionNegotiated;
+};
+
+partial dictionary RTCConfiguration {
+  RTCRtpHeaderEncryptionPolicy rtpHeaderEncryptionPolicy = "negotiate";
+};
+
+partial interface RTCRtpReceiver {
+  static undefined disableHardwareDecoding();
+};
+
+partial interface RTCRtpSender {
+  static undefined disableHardwareEncoding();
+};


### PR DESCRIPTION
This will allow jitterBufferTarget to be tested:
https://github.com/mdn/browser-compat-data/pull/22681
