### PR TITLE
Set a source for the SVG image element

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -5177,7 +5177,11 @@ api:
     __base: var instance = document.createElementNS('http://www.w3.org/2000/svg', 'hkern');
     __test: return bcd.testObjectName(instance, 'SVGHKernElement');
   SVGImageElement:
-    __base: var instance = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+    __resources:
+      - image-black
+    __base: |-
+      var instance = document.createElementNS('http://www.w3.org/2000/svg', 'image');
+      svgimg.href.baseVal = document.getElementById("resource-image-black").src; // Set a source for the image, required for certain tests
     __test: return bcd.testObjectName(instance, 'SVGImageElement');
   SVGLength:
     __base: |-


### PR DESCRIPTION
This PR is a follow-up fix to #1410.  The `createImageBitmap` function requires an image to be loaded to pass.
