### PR TITLE
Allow update-bcd to accept files as filepaths, rather than just dirs

### DIFF
--- a/scripts/update-bcd.ts
+++ b/scripts/update-bcd.ts
@@ -1295,8 +1295,14 @@ export const loadJsonFiles = async (
   const jsonFiles: string[] = [];
 
   for (const p of paths) {
-    for (const item of await jsonCrawler.crawl(p).withPromise()) {
-      jsonFiles.push(item);
+    if (fs.lstatSync(p).isFile()) {
+      if (p.endsWith(".json")) {
+        jsonFiles.push(p);
+      }
+    } else {
+      for (const item of await jsonCrawler.crawl(p).withPromise()) {
+        jsonFiles.push(item);
+      }
     }
   }
 


### PR DESCRIPTION
This PR updates the `update-bcd` script so that the reports path argument may accept direct files, rather than just folders.
