### PR TITLE
Allow UA parser to parse runtime-compat UA strings

### DIFF
--- a/lib/ua-parser.test.ts
+++ b/lib/ua-parser.test.ts
@@ -13,9 +13,11 @@ import {getMajorMinorVersion, parseUA} from "./ua-parser.js";
 const browsers = {
   chrome: {name: "Chrome", releases: {82: {}, 83: {}, 84: {}, 85: {}}},
   chrome_android: {name: "Chrome Android", releases: {85: {}}},
+  deno: {name: "Deno", releases: {1.42: {}}},
   edge: {name: "Edge", releases: {16: {}, 84: {}}},
   firefox: {name: "Firefox", releases: {3.6: {}}},
   ie: {name: "Internet Explorer", releases: {8: {}, 11: {}}},
+  nodejs: {name: "Node.js", releases: {"20.20.0": {}}},
   safari: {
     name: "Safari",
     releases: {13: {}, 13.1: {}, 14: {}, 15: {}, 15.1: {}, 15.2: {}},
@@ -498,6 +500,26 @@ describe("parseUA", () => {
         inBcd: true,
       },
     );
+  });
+
+  it("Node.js (data from unjs/runtime-compat)", () => {
+    assert.deepEqual(parseUA("!! node/20.20.1", browsers), {
+      browser: {id: "nodejs", name: "Node.js"},
+      version: "20.20.0",
+      fullVersion: "20.20.1",
+      os: {name: "", version: ""},
+      inBcd: true,
+    });
+  });
+
+  it("Deno (data from unjs/runtime-compat)", () => {
+    assert.deepEqual(parseUA("!! deno/1.42", browsers), {
+      browser: {id: "deno", name: "Deno"},
+      version: "1.42",
+      fullVersion: "1.42",
+      os: {name: "", version: ""},
+      inBcd: true,
+    });
   });
 
   it("Chrome on iOS (not in BCD)", () => {

--- a/lib/ua-parser.ts
+++ b/lib/ua-parser.ts
@@ -42,7 +42,7 @@ const getMajorMinorVersion = (version: string): string => {
  */
 const parseUA = (userAgent: string, browsers: Browsers): ParsedUserAgent => {
   const ua = uaParser(userAgent);
-  const data: ParsedUserAgent = {
+  let data: ParsedUserAgent = {
     browser: {id: "", name: ""},
     version: "",
     fullVersion: "",
@@ -50,14 +50,21 @@ const parseUA = (userAgent: string, browsers: Browsers): ParsedUserAgent => {
     inBcd: undefined,
   };
 
-  if (!ua.browser.name) {
-    return data;
-  }
+  if (userAgent.startsWith("!! ")) {
+    // UA strings in unjs/runtime-compat are prepended with this string to prevent incorrect parsing by standard UA libs
+    const [runtime, runtimeVersion] = userAgent.replace("!! ", "").split("/");
+    data.browser.id = runtime;
+    data.fullVersion = runtimeVersion;
+  } else {
+    if (!ua.browser.name) {
+      return data;
+    }
 
-  data.browser.id = ua.browser.name.toLowerCase().replace(/ /g, "_");
-  data.browser.name = ua.browser.name;
-  data.os.name = ua.os.name || "";
-  data.os.version = ua.os.version || "";
+    data.browser.id = ua.browser.name.toLowerCase().replace(/ /g, "_");
+    data.browser.name = ua.browser.name;
+    data.os.name = ua.os.name || "";
+    data.os.version = ua.os.version || "";
+  }
 
   switch (data.browser.id) {
     case "mobile_safari":
@@ -72,6 +79,9 @@ const parseUA = (userAgent: string, browsers: Browsers): ParsedUserAgent => {
     case "android_browser":
     case "chrome_webview":
       data.browser.id = "webview";
+      break;
+    case "node":
+      data.browser.id = "nodejs";
       break;
   }
 

--- a/lib/ua-parser.ts
+++ b/lib/ua-parser.ts
@@ -42,7 +42,7 @@ const getMajorMinorVersion = (version: string): string => {
  */
 const parseUA = (userAgent: string, browsers: Browsers): ParsedUserAgent => {
   const ua = uaParser(userAgent);
-  let data: ParsedUserAgent = {
+  const data: ParsedUserAgent = {
     browser: {id: "", name: ""},
     version: "",
     fullVersion: "",


### PR DESCRIPTION
This PR updates the UA parser lib to be able to parse the slightly custom UA strings that `runtime-compat` data produces.  `runtime-compat` prepends two exlamation points in the UA string to prevent standard UA parsers from parsing the string and returning bogus results.
