### PR TITLE
Use latest commit for ejs-lint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
         "chalk-template": "1.1.0",
         "cheerio": "^1.0.0-rc.12",
         "core-js": "^3.37.0",
-        "ejs-lint": "2.0.0",
+        "ejs-lint": "github:RyanZim/EJS-Lint#7e7d5681ba8d2c768e15a3d77c84662a78ea8db1",
         "enquirer": "2.4.1",
         "es-scraper": "^0.0.13",
         "eslint": "8.57.0",
@@ -6457,12 +6457,13 @@
     },
     "node_modules/ejs-lint": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ejs-lint/-/ejs-lint-2.0.0.tgz",
-      "integrity": "sha512-zt3E6MWLBYpWuUEOFRRqzB74gxCOZJAzoKmJR810U2mIrLnP1v6Xyk8tc6tl4pbT63cFoEqELPx9K8URjmpyZg==",
+      "resolved": "git+ssh://git@github.com/RyanZim/EJS-Lint.git#7e7d5681ba8d2c768e15a3d77c84662a78ea8db1",
+      "integrity": "sha512-CERpLimAlqj8TVSETm158+m35fPTsHtxwX0RI95aY7Atzoewq45+18m/dVSIGirn6REia0y0w/dR9LYbO29/hQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
-        "ejs": "3.1.8",
+        "ejs": "3.1.10",
         "ejs-include-regex": "^1.0.0",
         "globby": "^13.0.0",
         "read-input": "^0.3.1",
@@ -6472,21 +6473,6 @@
       },
       "bin": {
         "ejslint": "cli.js"
-      }
-    },
-    "node_modules/ejs-lint/node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
-      "dev": true,
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ejs-lint/node_modules/globby": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "chalk-template": "1.1.0",
     "cheerio": "^1.0.0-rc.12",
     "core-js": "^3.37.0",
-    "ejs-lint": "2.0.0",
+    "ejs-lint": "github:RyanZim/EJS-Lint#7e7d5681ba8d2c768e15a3d77c84662a78ea8db1",
     "enquirer": "2.4.1",
     "es-scraper": "^0.0.13",
     "eslint": "8.57.0",


### PR DESCRIPTION
`ejs-lint` has hardcoded EJS versions as a dependency, but hasn't been updated in a while, and the version it depends on has a security vulnerability.  This PR uses the latest commit, which bumps the EJS version.
