### PR TITLE
Add tests for non-registered symbols in Weak{Map,Set,Ref} and FinalizationRegistry

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6279,12 +6279,9 @@ javascript:
     FinalizationRegistry:
       __additional:
         symbol_as_target: |-
-          try {
-            new FinalizationRegistry(() => {}).register(Symbol());
-            return true;
-          } catch(e) {
-            return {result: false, message: e.message};
-          }
+          return bcd.testOk(function() {
+            new FinalizationRegistry(function() {}).register(Symbol());
+          });
     Float32Array:
       __additional:
         Float32Array.iterable_allowed: |-
@@ -6659,21 +6656,15 @@ javascript:
             return {result: false, message: e.message};
           }
         symbol_as_keys: |-
-          try {
+          return bcd.testOk(function() {
             new WeakMap().set(Symbol(), null);
-            return true;
-          } catch(e) {
-            return {result: false, message: e.message};
-          }
+          });
     WeakRef:
       __additional:
         symbol_as_target: |-
-          try {
+          return bcd.testOk(function() {
             new WeakRef(Symbol());
-            return true;
-          } catch(e) {
-            return {result: false, message: e.message};
-          }
+          });
     WeakSet:
       __additional:
         WeakSet.iterable_allowed: |-
@@ -6691,12 +6682,9 @@ javascript:
             return {result: false, message: e.message};
           }
         symbol_as_keys: |-
-          try {
+          return bcd.testOk(function() {
             new WeakSet().add(Symbol());
-            return true;
-          } catch(e) {
-            return {result: false, message: e.message};
-          }
+          });
 
 # Features defined here also need to be in test-builder/webassembly.ts.
 webassembly:

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6276,6 +6276,15 @@ javascript:
           options_cause_parameter: |-
             var e = new Error('foo', {cause: 'testing'});
             return e.cause === 'testing';
+    FinalizationRegistry:
+      __additional:
+        symbol_as_target: |-
+          try {
+            new FinalizationRegistry(() => {}).register(Symbol());
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
     Float32Array:
       __additional:
         Float32Array.iterable_allowed: |-
@@ -6649,6 +6658,22 @@ javascript:
           } catch(e) {
             return {result: false, message: e.message};
           }
+        symbol_as_keys: |-
+          try {
+            new WeakMap().set(Symbol(), null);
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
+    WeakRef:
+      __additional:
+        symbol_as_target: |-
+          try {
+            new WeakRef(Symbol());
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
     WeakSet:
       __additional:
         WeakSet.iterable_allowed: |-
@@ -6661,6 +6686,13 @@ javascript:
         WeakSet.null_allowed: |-
           try {
             new WeakSet(null);
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
+        symbol_as_keys: |-
+          try {
+            new WeakSet().add(Symbol());
             return true;
           } catch(e) {
             return {result: false, message: e.message};

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6279,9 +6279,12 @@ javascript:
     FinalizationRegistry:
       __additional:
         symbol_as_target: |-
-          return bcd.testOk(function() {
-            new FinalizationRegistry(function() {}).register(Symbol());
-          });
+          try {
+            new FinalizationRegistry(() => {}).register(Symbol());
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
     Float32Array:
       __additional:
         Float32Array.iterable_allowed: |-
@@ -6656,15 +6659,21 @@ javascript:
             return {result: false, message: e.message};
           }
         symbol_as_keys: |-
-          return bcd.testOk(function() {
+          try {
             new WeakMap().set(Symbol(), null);
-          });
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
     WeakRef:
       __additional:
         symbol_as_target: |-
-          return bcd.testOk(function() {
+          try {
             new WeakRef(Symbol());
-          });
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
     WeakSet:
       __additional:
         WeakSet.iterable_allowed: |-
@@ -6682,9 +6691,12 @@ javascript:
             return {result: false, message: e.message};
           }
         symbol_as_keys: |-
-          return bcd.testOk(function() {
+          try {
             new WeakSet().add(Symbol());
-          });
+            return true;
+          } catch(e) {
+            return {result: false, message: e.message};
+          }
 
 # Features defined here also need to be in test-builder/webassembly.ts.
 webassembly:

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -626,40 +626,6 @@
   }
 
   /**
-   * Wrap error or other thrown value into a test result
-   * @param {unknown} e - The error or value to wrap
-   * @returns {TestResult} The wrapped test result
-   */
-  function wrapThrownValue(e) {
-    return {
-      result: false,
-      message: e instanceof Error ? e.message : String(e)
-    };
-  }
-
-  /**
-   * Run the supplied function, returning success result if OK/promise resolves
-   * or error result if throws/promise rejects
-   * @param {() => void | Promise<void>} fn - The function to test
-   * @returns {TestResult} The result of the test
-   */
-  function testOk(fn) {
-    try {
-      var result = fn();
-
-      if (result instanceof Promise) {
-        return result.then(function () {
-          return true;
-        }, wrapThrownValue);
-      }
-
-      return true;
-    } catch (e) {
-      return wrapThrownValue(e);
-    }
-  }
-
-  /**
    * Test a web assembly feature for support, using the `wasm-feature-detect` Node package
    * @param {string} feature - The web assembly feature name as defined in `wasm-feature-detect`
    * @returns {TestResult} - Whether the web assembly feature is supported
@@ -1894,7 +1860,6 @@
     testOptionParam: testOptionParam,
     testCSSProperty: testCSSProperty,
     testCSSSelector: testCSSSelector,
-    testOk: testOk,
     testWasmFeature: testWasmFeature,
     addInstance: addInstance,
     addTest: addTest,

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -626,6 +626,40 @@
   }
 
   /**
+   * Wrap error or other thrown value into a test result
+   * @param {unknown} e - The error or value to wrap
+   * @returns {TestResult} The wrapped test result
+   */
+  function wrapThrownValue(e) {
+    return {
+      result: false,
+      message: e instanceof Error ? e.message : String(e)
+    };
+  }
+
+  /**
+   * Run the supplied function, returning success result if OK/promise resolves
+   * or error result if throws/promise rejects
+   * @param {() => void | Promise<void>} fn - The function to test
+   * @returns {TestResult} The result of the test
+   */
+  function testOk(fn) {
+    try {
+      var result = fn();
+
+      if (result instanceof Promise) {
+        return result.then(function () {
+          return true;
+        }, wrapThrownValue);
+      }
+
+      return true;
+    } catch (e) {
+      return wrapThrownValue(e);
+    }
+  }
+
+  /**
    * Test a web assembly feature for support, using the `wasm-feature-detect` Node package
    * @param {string} feature - The web assembly feature name as defined in `wasm-feature-detect`
    * @returns {TestResult} - Whether the web assembly feature is supported
@@ -1860,6 +1894,7 @@
     testOptionParam: testOptionParam,
     testCSSProperty: testCSSProperty,
     testCSSSelector: testCSSSelector,
+    testOk: testOk,
     testWasmFeature: testWasmFeature,
     addInstance: addInstance,
     addTest: addTest,

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -313,7 +313,9 @@
           "target",
           "Promise resolver undefined",
           "type must not be undefined",
-          "must be callable"
+          "must be callable",
+          "is not a non-null object",
+          "is not a function"
         ])
       ) {
         // If it failed to construct and it's not illegal or just needs


### PR DESCRIPTION
~~I've added a `testOk` harness as similar `try { testLogic(); return true } catch(e) { return { result: false, message: e.message } }` logic seems to be repeated a lot, but I've only used it for the newly added tests for now.~~