### PR TITLE
feat: Update constructor judgments of LLRT

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -316,7 +316,8 @@
           "must be callable",
           "is not a non-null object",
           "is not a function",
-          "Failed to construct" // Used by workerd
+          "Failed to construct", // Used by workerd
+          "Error calling function with"
         ])
       ) {
         // If it failed to construct and it's not illegal or just needs


### PR DESCRIPTION
In [LLRT](https://github.com/awslabs/llrt), this corresponds to the following message that occurs in the execution of the constructor of an object that requires one or more arguments.

See also. https://github.com/unjs/runtime-compat/issues/126

```json
      {
        "name": "api.Request.Request",
        "info": {
          "code": "bcd.testConstructor('Request')",
          "exposure": "Window"
        },
        "result": null,
        "message": "threw TypeError: Error calling function with 0 argument(s) while 1 where expected"
      },
```

Execution results in LLRT (cli mode):
```
% ./llrt -v                              
LLRT (darwin arm64) 0.1.14-beta

% ./llrt -e "const req = new Request();"                     
TypeError: Error calling function with 0 argument(s) while 1 where expected
    at <eval> (eval_script:1:13)
```