### PR TITLE
Remove invalid SVG global attribute tests

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -568,29 +568,8 @@
     "global_attributes": {
       "attributes": [
         {"class": "className", "tabindex": "tabIndex"},
-        "clip",
-        "color",
-        "cursor",
-        "data",
-        "direction",
-        "display",
-        "fill",
-        "filter",
-        "href",
         "id",
-        "kerning",
-        "lang",
-        "mask",
-        "opacity",
-        "overflow",
-        "requiredExtensions",
-        "requiredFeatures",
-        "stroke",
-        "style",
-        "systemLanguage",
-        "textLength",
-        "transform",
-        "visibility"
+        "style"
       ]
     },
     "cursor": {


### PR DESCRIPTION
For most of these, there is no IDL attribute defined by SVG or any other
spec (such as filter effects) and no browser seems to have them as
non-standard extensions.

A few of these do however have IDL attributes defined, but in mixins
that are included by specific SVG elements interfaces:

href: https://svgwg.org/svg2-draft/types.html#InterfaceSVGURIReference
requiredExtensions: https://svgwg.org/svg2-draft/types.html#InterfaceSVGTests
systemLanguage: https://svgwg.org/svg2-draft/types.html#InterfaceSVGTests

textLength is only for SVGTextContentElement.

transform is only for SVGGraphicsElement.

The removed tests all fail in Chrome, Firefox and Safari. The remaining
4 tests all pass.
