### PR TITLE
Fix the tests for checkVisibility() parameters

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -1562,6 +1562,7 @@ api:
         options_checkOpacity_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'checkOpacity', true);"
         options_checkVisibilityCSS_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'checkVisibilityCSS', true);"
         options_contentVisibilityAuto_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'contentVisibilityAuto', true);"
+        options_opacityProperty_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'opacityProperty', true);"
         options_visibilityProperty_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'visibilityProperty', true);"
     getElementsByTagName:
       __additional:

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -1559,10 +1559,10 @@ api:
           return bcd.testOptionParam(el, 'attachShadow', 'delegatesFocus', true, {mode: 'open'});
     checkVisibility:
       __additional:
-        options_checkOpacity_parameter: "return bcd.testOptionParam(interface, 'checkVisibility', 'checkOpacity', true);"
-        options_checkVisibilityCSS_parameter: "return bcd.testOptionParam(interface, 'checkVisibility', 'checkVisibilityCSS', true);"
-        options_contentVisibilityAuto_parameter: "return bcd.testOptionParam(interface, 'checkVisibility', 'contentVisibilityAuto', true);"
-        options_visibilityProperty_parameter: "return bcd.testOptionParam(interface, 'checkVisibility', 'visibilityProperty', true);"
+        options_checkOpacity_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'checkOpacity', true);"
+        options_checkVisibilityCSS_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'checkVisibilityCSS', true);"
+        options_contentVisibilityAuto_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'contentVisibilityAuto', true);"
+        options_visibilityProperty_parameter: "return bcd.testOptionParam(instance, 'checkVisibility', 'visibilityProperty', true);"
     getElementsByTagName:
       __additional:
         all_elements_selector: |-


### PR DESCRIPTION
A simple typo broke these tests. They pass on Safari 17.5 with this change.
