### PR TITLE
Add float16array builtins

### DIFF
--- a/custom/js.json
+++ b/custom/js.json
@@ -21,6 +21,11 @@
         ]
       }
     },
+    "DataView": {
+      "members": {
+        "instance": ["getFloat16", "setFloat16"]
+      }
+    },
     "Error": {
       "members": {
         "instance": [
@@ -34,11 +39,19 @@
         ]
       }
     },
+    "Float16Error": {
+      "ctor": {}
+    },
     "Function": {
       "members": {"instance": ["arguments", "caller", "length"]}
     },
     "InternalError": {
       "ctor": {}
+    },
+    "Math": {
+      "members": {
+        "static": ["f16round"]
+      }
     },
     "Promise": {
       "__comment": "Remove when https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers is merged into the main ECMAScript spec.",


### PR DESCRIPTION
Not picked up automatically because we're not scraping all ECMAScript specs, see https://github.com/openwebdocs/mdn-bcd-collector/issues/893