### PR TITLE
Selenium: use Chrome Stable support variations for beta releases

### DIFF
--- a/scripts/selenium.ts
+++ b/scripts/selenium.ts
@@ -411,6 +411,7 @@ const buildDriver = async (
           args: [
             "--use-fake-device-for-media-stream",
             "--use-fake-ui-for-media-stream",
+            "--fake-variations-channel=stable",
           ],
           prefs: {
             "profile.managed_default_content_settings.geolocation": 1,


### PR DESCRIPTION
This PR adds a command line argument when running Chrome via Selenium which tells Chrome to behave as if it is a stable release at all times, including beta/canary releases.
