### PR TITLE
Fix test code for DOMException (for JS runtimes)

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -1367,10 +1367,16 @@ api:
   DOMException:
     __base: |-
       var instance;
-      try {
-        document.createElement('1');
-      } catch (e) {
-        instance = e;
+      if ("DOMException" in self) {
+        instance = new DOMException();
+      } else if ("document" in self) {
+        try {
+          document.createElement('1');
+        } catch (e) {
+          instance = e;
+        }
+      } else {
+        return {result: false, message: "DOMException and document are both undefined"}
       }
   DOMImplementation:
     __base: var instance = document.implementation;


### PR DESCRIPTION
While synchronizing BCD and RCD results, I found that https://runtime-compat.unjs.io/#DOMException reports support only because it's generating an error, just not the one we expect.  This PR updates the test code to check for `document` first, so we don't throw an UndefinedError instead.
