### PR TITLE
Remove onoverconstrained custom idl

### DIFF
--- a/custom/idl/mediacapture-streams.idl
+++ b/custom/idl/mediacapture-streams.idl
@@ -8,9 +8,3 @@ interface MediaStreamEvent : Event {
   constructor();
   readonly attribute MediaStream stream;
 };
-
-partial interface MediaStreamTrack {
-
-  // https://github.com/w3c/mediacapture-main/pull/576
-  attribute EventHandler onoverconstrained;
-};


### PR DESCRIPTION
https://github.com/w3c/mediacapture-main/pull/576 was merged. This is gone.