### PR TITLE
Remove <img> onerror

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -240,7 +240,6 @@
         "hspace",
         "loading",
         "name",
-        "onerror",
         "sizes",
         "src",
         "srcset",


### PR DESCRIPTION
We don't document event handlers as HTML attributes. The collector shouldn't propose this as a data addition.