### PR TITLE
Remove <script text> attribute

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -377,7 +377,6 @@
         "defer",
         "integrity",
         "src",
-        "text",
         "type"
       ]
     },


### PR DESCRIPTION
There is no `text` attribute on the HTML `<script>` element. It exists on the API, however. https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement/text