### PR TITLE
Fix MathML tests

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6029,9 +6029,9 @@ mathml:
         // Use tall enough fraction to avoid side effect of min num/denum shifts.
         var mathEl = document.createElementNS("http://www.w3.org/1998/Math/MathML", "math");
         mathEl.innerHTML = "<mfrac><mspace height='50px' depth='50px'></mspace><mspace height='50px' depth='50px'></mspace></mfrac><mfrac><mspace height='60px' depth='60px'></mspace><mspace height='60px' depth='60px'></mspace></mfrac>";
-        document.getElementById('resources').appendChild(mathEl);
+        document.body.appendChild(mathEl);
         bcd.addCleanup(function() {
-          document.getElementById('resources').removeChild(mathEl);
+          document.body.removeChild(mathEl);
         });
 
         var mfrac = mathEl.getElementsByTagName("mfrac");
@@ -6087,9 +6087,9 @@ mathml:
       __base: |-
         var mathEl = document.createElementNS("http://www.w3.org/1998/Math/MathML", "math");
         mathEl.innerHTML = "<mspace></mspace><mspace width='20px'></mspace>";
-        document.getElementById('resources').appendChild(mathEl);
+        document.body.appendChild(mathEl);
         bcd.addCleanup(function() {
-          document.getElementById('resources').removeChild(mathEl);
+          document.body.removeChild(mathEl);
         });
 
         // The width attribute will add 20px per MathML and none if not supported.
@@ -6099,9 +6099,9 @@ mathml:
       __base: |-
         var mathEl = document.createElementNS("http://www.w3.org/1998/Math/MathML", "math");
         mathEl.innerHTML = "<mrow style='font-size: 20px !important'><mtext>A</mtext></mrow><msqrt style='font-size: 20px !important'><mtext>A</mtext></msqrt>";
-        document.getElementById('resources').appendChild(mathEl);
+        document.body.appendChild(mathEl);
         bcd.addCleanup(function() {
-          document.getElementById('resources').removeChild(mathEl);
+          document.body.removeChild(mathEl);
         });
 
         // The radical symbol will make msqrt wider than mrow, if the former is supported.
@@ -6147,9 +6147,9 @@ mathml:
       __base: |-
         var mathEl = document.createElementNS("http://www.w3.org/1998/Math/MathML", "math");
         mathEl.innerHTML = "<munderover><mspace width='20px'></mspace><mspace width='20px'></mspace><mspace width='20px'></mspace></munderover><munderover><mspace width='40px'></mspace><mspace width='40px'></mspace><mspace width='40px'></mspace></munderover>";
-        document.getElementById('resources').appendChild(mathEl);
+        document.body.appendChild(mathEl);
         bcd.addCleanup(function() {
-          document.getElementById('resources').removeChild(mathEl);
+          document.body.removeChild(mathEl);
         });
 
         var munderover = mathEl.getElementsByTagName("munderover");


### PR DESCRIPTION
Reverts https://github.com/openwebdocs/mdn-bcd-collector/pull/1180. 

The MathML tests rely on `getBoundingClientRect()` and that method does not work with `display:none` elements!