### PR TITLE
Update extension IDs for NordPass

### DIFF
--- a/browser-extensions.json
+++ b/browser-extensions.json
@@ -3,8 +3,8 @@
     "name": "NordPass",
     "message": "NordPass performs polyfill-like transformations on navigator.credentials, affecting tests for the CredentialsContainer API.",
     "affectedTests": ["api.CredentialsContainer"],
-    "chromeId": "fooolghllnmhmmndgjiamiiodkpenpbb",
-    "firefoxId": "3a147c47-c111-4048-9bc5-d72f227311fe",
+    "chromeId": "eiaeiblijfjekdanodkjadfinkhbfgcd",
+    "firefoxId": "0ff38d7a-db91-4a1a-a222-00f10d098b22",
     "safariId": "9F9F9D62-DE32-4B4F-88FD-63D448DACFDC"
   }
 }


### PR DESCRIPTION
NordPass created brand new versions of their extensions which ended up causing the extension UIDs to change.  This PR updates the browser extensions data list accordingly.
