### PR TITLE
Ignore `transform` property values in `transform-function` type

### DIFF
--- a/test-builder/css.ts
+++ b/test-builder/css.ts
@@ -239,6 +239,16 @@ const buildPropertyTests = async (specCSS, customCSS) => {
         overflow: ["overlay"],
         "overflow-x": ["overlay"],
         "overflow-y": ["overlay"],
+        transform: [
+          "matrix",
+          "translate",
+          "translateX",
+          "translateY",
+          "rotate",
+          "skew",
+          "skewX",
+          "skewY",
+        ],
       };
 
       const propertyValues = remapPropertyValues(


### PR DESCRIPTION
This fixes https://github.com/openwebdocs/mdn-bcd-collector/issues/1568.
