### PR TITLE
Drop tests for menclose and mfenced MathML elements

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -964,15 +964,9 @@
       ]
     }
   },
-  "mathml": {
-    "menclose": {
-      "__comment": "XXX MathML attributes are disabled until it can be determined how to properly test them. (Remove the two underscores when ready.)",
-      "__attributes": ["notation"]
-    },
-    "mfenced": {}
-  },
+  "mathml": {},
   "__mathml": {
-    "__comment": "XXX MathML attributes are disabled until it can be determined how to properly test them. (Remove the two underscores and merge with above when ready.)",
+    "__comment": "XXX MathML attributes are disabled until it can be determined how to properly test them. (Remove the two underscores in the category name when ready.)",
     "maction": {"attributes": ["actiontype", "selection"]},
     "math": {"attributes": ["display"]},
     "mfrac": {"attributes": ["denomalign", "linethickness", "numalign"]},

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6135,18 +6135,7 @@ mathml:
       // XXX Improve feature detection
       <%mathml.elements.mspace:instance%>
       return has_mspace;
-    menclose: |-
-      // Just check whether <mrow> is supported because discussion on this is
-      // still open (https://github.com/mathml-refresh/mathml/issues/105 
-      // and it would have to behave at least like an mrow, even if it becomes
-      // an unknown element at the end.
-      <%mathml.elements.mrow:instance%>
-      return has_mspace;
     merror: |-
-      // XXX Improve feature detection
-      <%mathml.elements.mspace:instance%>
-      return has_mspace;
-    mfenced: |-
       // XXX Improve feature detection
       <%mathml.elements.mspace:instance%>
       return has_mspace;


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/23588#issuecomment-2199552712 for more details.