### PR TITLE
Track inline-[start/end] values of caption-side CSS property

### DIFF
--- a/custom/css.json
+++ b/custom/css.json
@@ -208,6 +208,8 @@
         "bottom",
         "left",
         "right",
+        "inline-start",
+        "inline-end",
         "top-outside",
         "bottom-outside"
       ]


### PR DESCRIPTION
This fixes https://github.com/mdn/browser-compat-data/issues/23245.
