### PR TITLE
Disable attribute testing for non-HTML element attributes

### DIFF
--- a/test-builder/elements.ts
+++ b/test-builder/elements.ts
@@ -167,7 +167,8 @@ const build = async (specElements, customElements) => {
       }
 
       // Add tests for the attributes
-      if (data.attributes) {
+      // XXX attribute tests for SVG and MathML disabled, need to determine how to properly test them
+      if (data.attributes && category === "html") {
         for (const [attrName, attrProp] of data.attributes.entries() as [
           string,
           string,

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -73,8 +73,7 @@ See the LICENSE file for copyright details
     <li>Detection for features under alternative names are not yet supported</li>
     <li>Some browser extensions, such as password managers, may cause compatibility conflicts</li>
     <li>CSS property value detection may produce false positives for certain properties</li>
-    <li>Many tests for SVG attributes are improper due to not having API counterparts, resulting in no support reported</li>
-    <li>Tests for MathML element attributes are not yet implemented</li>
+    <li>Tests for SVG and MathML element attributes are not yet implemented</li>
   </ul>
 
   <p id="known-caveats-file-issue">If you find any errors in feature detection, please <a href="https://github.com/openwebdocs/mdn-bcd-collector/issues/new"><span class="mdi mdi-alert-circle-outline"></span> file an issue</a> in the GitHub repository.</p>


### PR DESCRIPTION
This PR disables attribute testing for SVG element attributes.  Currently, the tests are problematic as there are no IDL counterparts for the attributes, and [if the spec is to be believed, this is by design](https://svgwg.org/specs/animations/#InterfaceSVGAnimateElement:~:text=Object%2Doriented%20access%20to%20the%20attributes%20of%20the%20%E2%80%98animate%E2%80%99%20element%20via%20the%20SVG%20DOM%20is%20not%20available).
