### PR TITLE
Disable GitHub export if not running all (category) tests

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -472,6 +472,7 @@ app.all("/tests/*", (req: Request, res: Response) => {
   if (foundTests && foundTests.length) {
     res.render("tests", {
       title: `${ident || "All Tests"}`,
+      ident,
       tests: foundTests,
       resources: tests.resources,
       selenium: req.query.selenium,

--- a/views/tests.ejs
+++ b/views/tests.ejs
@@ -14,7 +14,8 @@ See the LICENSE file for copyright details
 <p id="status">Ready to start tests</p>
 <form id="export" action="/export" method="post">
   <button id="export-download" class="export-button" type="submit" name="download" value="download" disabled><span class="mdi mdi-download"></span> Download results file</button>
-  <button id="export-github" class="export-button <% if (!github) {%>always-disabled<% } %>" type="submit" name="github" value="github" disabled><span class="mdi mdi-github"></span> <% if (github) {%>Send results to mdn-bcd-results GitHub repo<% } else { %>GitHub export disabled<% } %></button>
+  <% const githubDisabled = !github || ident.includes('.'); %>
+  <button id="export-github" class="export-button <% if (githubDisabled) {%>always-disabled<% } %>" type="submit" name="github" value="github" disabled><span class="mdi mdi-github"></span> <% if (!githubDisabled) {%>Send results to mdn-bcd-results GitHub repo<% } else { %>GitHub export disabled<% } %></button>
 </form>
 <div id="results">
   <hr />


### PR DESCRIPTION
This PR disables the GitHub export if the tests run are not for a top-level category, or all of the tests the collector can run.  A lot of results are submitted by various users, but a fair number of them are unhelpful as they are only for a single feature.  The intent of this PR is to cut down on unhelpful results by only allowing top-level categories to be submitted to GitHub.
