### PR TITLE
CSSStyleDeclaration is not iterable

### DIFF
--- a/custom/idl/cssom.idl
+++ b/custom/idl/cssom.idl
@@ -79,8 +79,8 @@ interface Counter {
 };
 
 partial interface CSSStyleDeclaration {
-  CSSValue getPropertyCSSValue(DOMString property);
-  iterable<CSSNumericValue>;
+  // non-standard in WebKit
+  CSSValue getPropertyCSSValue(DOMString property); 
 };
 
 // Non-standard stuff


### PR DESCRIPTION
I'm not sure why this was added. I don't see it being iterable in specs or in browsers.