### PR TITLE
Add tests for Promise.try

### DIFF
--- a/custom/js.json
+++ b/custom/js.json
@@ -57,9 +57,9 @@
       }
     },
     "Promise": {
-      "__comment": "Remove when https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers is merged into the main ECMAScript spec.",
+      "__comment": "Remove when https://tc39.es/proposal-promise-try and https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers are merged into the main ECMAScript spec.",
       "members": {
-        "static": ["withResolvers"]
+        "static": ["try", "withResolvers"]
       }
     },
     "RegExp": {


### PR DESCRIPTION
Not picked up automatically because we're not scraping all ECMAScript specs, see https://github.com/openwebdocs/mdn-bcd-collector/issues/893