### PR TITLE
Add RegExp.escape

### DIFF
--- a/custom/js.json
+++ b/custom/js.json
@@ -65,6 +65,7 @@
     "RegExp": {
       "members": {
         "static": [
+          "escape",
           "input",
           "lastIndex",
           "lastMatch",


### PR DESCRIPTION
From https://tc39.es/proposal-regex-escaping/

Not picked up automatically because we're not scraping all ECMAScript specs, see https://github.com/openwebdocs/mdn-bcd-collector/issues/893