### PR TITLE
Don't format test code with trailing comma

### DIFF
--- a/test-builder/common.ts
+++ b/test-builder/common.ts
@@ -310,7 +310,10 @@ const compileCustomTest = async (
 
     try {
       // Use Prettier to format code
-      code = await prettier.format(code, {parser: "babel"});
+      code = await prettier.format(code, {
+        parser: "babel",
+        trailingComma: "none",
+      });
     } catch (e) {
       if (e instanceof SyntaxError) {
         const errorMsg = `Test is malformed: ${e.message}`;


### PR DESCRIPTION
This is required to ensure compatibility with older browsers.
