### PR TITLE
chore(workflows): use Node version from .nvmrc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
       - run: npm ci
       - name: git config
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version-file: ".nvmrc"
       - name: Prepare browser-compat-data
         run: npm ci
         working-directory: browser-compat-data


### PR DESCRIPTION
I noticed that the workflows are still running with Node.js, although the repo was already bumped to Node 20 in https://github.com/openwebdocs/mdn-bcd-collector/pull/1644.