### PR TITLE
Use Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
I noticed the following warning on [this workflow run](https://github.com/openwebdocs/mdn-bcd-collector/actions/runs/11835362805/job/32977979053):

> The following actions uses node12 which is deprecated and will be forced to run on node16: akhileshns/heroku-deploy@v3.12.12.

But it looks like a newer version of the action is available: https://github.com/AkhileshNS/heroku-deploy/releases

So I figured the github-actions are just not automatically updated in this repo.

(I guess it's good to be cautious with this action though, as it does node version bumps in patch versions.)