### PR TITLE
Override `display: flow`

### DIFF
--- a/custom/overrides.json
+++ b/custom/overrides.json
@@ -1193,5 +1193,10 @@
   ["api.Window.location", "deno", "*", false],
   "Collector reporting earlier version than confirmed in https://bugzil.la/1887729",
   ["api.OffscreenCanvas.contextlost_event", "firefox", "105-124", false],
-  ["api.OffscreenCanvas.contextrestored_event", "firefox", "105-124", false]
+  ["api.OffscreenCanvas.contextrestored_event", "firefox", "105-124", false],
+  "https://github.com/mdn/browser-compat-data/pull/24386#discussion_r1792287025",
+  ["css.properties.display.flow", "chrome", "*", false]
+  ["css.properties.display.flow", "edge", "*", false]
+  ["css.properties.display.flow", "firefox", "*", false]
+  ["css.properties.display.flow", "safari", "*", false]
 ]

--- a/custom/overrides.json
+++ b/custom/overrides.json
@@ -1195,8 +1195,8 @@
   ["api.OffscreenCanvas.contextlost_event", "firefox", "105-124", false],
   ["api.OffscreenCanvas.contextrestored_event", "firefox", "105-124", false],
   "https://github.com/mdn/browser-compat-data/pull/24386#discussion_r1792287025",
-  ["css.properties.display.flow", "chrome", "*", false]
-  ["css.properties.display.flow", "edge", "*", false]
-  ["css.properties.display.flow", "firefox", "*", false]
+  ["css.properties.display.flow", "chrome", "*", false],
+  ["css.properties.display.flow", "edge", "*", false],
+  ["css.properties.display.flow", "firefox", "*", false],
   ["css.properties.display.flow", "safari", "*", false]
 ]


### PR DESCRIPTION
The `flow` value seems to behave like `block`, i.e. after setting it to `flow` it reads as `block` afterwards, so the collector cannot determine the support status.

For some reason, `CSS.supports('display: flow')` returns `false` in Chrome 114 and `true` in Chrome 115, but I couldn't find any matching entry in https://chromium.googlesource.com/chromium/src/+log/114.0.5735.199..115.0.5790.99?pretty=fuller&n=10000.

See: https://github.com/mdn/browser-compat-data/pull/24386/files#r1792287025