### PR TITLE
Update CSS tests

### DIFF
--- a/custom/css.json
+++ b/custom/css.json
@@ -236,7 +236,7 @@
       }
     },
     "cursor": {
-      "__values": ["-moz-zoom", "-webkit-zoom", "inherit"],
+      "__values": ["-moz-zoom", "-webkit-zoom"],
       "__additional_values": {
         "url": "url(hand.cur), pointer",
         "url_positioning_syntax": "url(cursor_1.png) 4 12, auto"

--- a/custom/css.json
+++ b/custom/css.json
@@ -35,11 +35,6 @@
     "-webkit-margin-after": {},
     "-webkit-margin-before": {},
     "-webkit-marquee": {},
-    "-webkit-mask-box-image-outset": {},
-    "-webkit-mask-box-image-repeat": {},
-    "-webkit-mask-box-image-slice": {},
-    "-webkit-mask-box-image-source": {},
-    "-webkit-mask-box-image-width": {},
     "-webkit-mask-box-image": {},
     "-webkit-mask-composite": {},
     "-webkit-mask-position-x": {},
@@ -57,7 +52,6 @@
     "-webkit-rtl-ordering": {},
     "-webkit-tap-highlight-color": {},
     "-webkit-text-combine": {},
-    "-webkit-text-decoration-skip": {},
     "-webkit-text-decorations-in-effect": {},
     "-webkit-text-fill-color": {},
     "-webkit-text-security": {},
@@ -70,7 +64,6 @@
     "-webkit-transform-origin-y": {},
     "-webkit-transform-origin-z": {},
     "-webkit-user-drag": {},
-    "-webkit-user-modify": {},
     "alt": {},
     "animation-timing-function": {
       "__additional_values": {

--- a/test-builder/css.ts
+++ b/test-builder/css.ts
@@ -197,6 +197,7 @@ const buildPropertyTests = async (specCSS, customCSS) => {
           "grid-gap",
           "grid-column-gap",
           "grid-row-gap",
+          'word-wrap',
         ].includes(prop.name)
       ) {
         // Ignore any aliases defined in specs

--- a/test-builder/css.ts
+++ b/test-builder/css.ts
@@ -197,7 +197,7 @@ const buildPropertyTests = async (specCSS, customCSS) => {
           "grid-gap",
           "grid-column-gap",
           "grid-row-gap",
-          'word-wrap',
+          "word-wrap",
         ].includes(prop.name)
       ) {
         // Ignore any aliases defined in specs


### PR DESCRIPTION
Some CSS test updates:

- The -webkit-mask-box-image properties are gone with https://github.com/mdn/browser-compat-data/pull/25155
- -webkit-user-modify was removed with https://github.com/mdn/browser-compat-data/pull/24885
- -webkit-text-decoration-skip was removed with https://github.com/mdn/browser-compat-data/pull/24884
- word-wrap is an alias to overflow-wrap, so it should be ignored https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap
- cursor: inherit should be a sub feature as we record inherit as a global value