### PR TITLE
Revert "Add test for ImageData() settings parameter"

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -3131,13 +3131,6 @@ api:
         <%api.CanvasRenderingContext2D:ctx%>
         instance = ctx.createImageData(16, 16);
       }
-    __additional:
-      ImageData.settings_parameter: |-
-        if (!('ImageData' in self)) {
-          return {result: false, message: 'ImageData is not defined'}
-        }
-        instance = new ImageData(16, 16, { colorSpace: "display-p3" });
-        return instance.colorSpace == "display-p3";
   InkPresenter:
     __base: |-
       if (!('ink' in navigator)) {


### PR DESCRIPTION
Reverts openwebdocs/mdn-bcd-collector#1798

I don't think it is useful to just add an abstract `settings_parameter` sub feature here.

Better would be to have 
- ImageData.ImageData.settings_colorSpace_parameter
- ImageData.ImageData.settings_desynchronized_parameter

Or something that is more aligned with BCD conventions. 