### PR TITLE
Add custom test for NavigationActivation

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -3544,6 +3544,12 @@ api:
         data_text_parameter: |-
           // If `canShare` supports the parameter, `share` does
           return bcd.testOptionParam(instance, 'canShare', 'text', 'foo bar');
+  NavigationActivation:
+    __base: |-
+      if (!('navigation' in self)) {
+        return {result: false, message: 'navigation is not defined'}
+      }
+      var instance = navigation.activation;
   Node:
     __base: var instance = document;
   NodeList:


### PR DESCRIPTION
This adds a custom test for NavigationActivation to avoid false positives from early exposure.  Closes https://github.com/mdn/browser-compat-data/pull/25279.
