### PR TITLE
Remove coord_box from offset-path

### DIFF
--- a/custom/css.json
+++ b/custom/css.json
@@ -506,7 +506,6 @@
     "offset-path": {
       "__additional_values": {
         "basic_shape": "circle(50px at 0 100px)",
-        "coord_box": "content-box",
         "path": "path('M20,20 L50,80 L80,20')",
         "ray": "ray(45deg closest-side contain)",
         "url": "url(test.png)"


### PR DESCRIPTION
Merge if https://github.com/mdn/browser-compat-data/pull/25385 is merged.
We get content-box and all the other values through webref and other CSS properties also list them individually in BCD.