### PR TITLE
fix(scripts): use ts-node for start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:tests": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning test-builder/index.ts",
     "build:resources": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning prepare-resources.ts",
     "gcp-build": "npm run build",
-    "start": "node app.js",
+    "start": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning app.ts",
     "dev": "npm i && npm run build:tests && npm run build:resources && nf -j Procfile.dev start",
     "unittest": "NODE_ENV=test c8 mocha --recursive './**/*.test.ts'",
     "coverage": "npm run coverage:report && npm run coverage:open",


### PR DESCRIPTION
### Before

```
% npm start

> mdn-bcd-collector@10.12.8 start
> node app.js

node:internal/modules/cjs/loader:1228
  throw err;
  ^

Error: Cannot find module '/Users/claas/github/openwebdocs/mdn-bcd-collector/app.js'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1225:15)
    at Module._load (node:internal/modules/cjs/loader:1051:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.18.0
```

### After

```
% npm start

> mdn-bcd-collector@10.12.8 start
> node --loader=ts-node/esm --no-warnings=ExperimentalWarning app.ts

info: Listening on port 8080 (HTTP)
info: Press Ctrl+C to quit.
```