### PR TITLE
Replace usages of `Object.keys()`

### DIFF
--- a/browser-extensions.json
+++ b/browser-extensions.json
@@ -1,5 +1,6 @@
-{
-  "nordpass": {
+[
+  {
+    "key": "nordpass",
     "name": "NordPass",
     "message": "NordPass performs polyfill-like transformations on navigator.credentials, affecting tests for the CredentialsContainer API.",
     "affectedTests": ["api.CredentialsContainer"],
@@ -7,4 +8,4 @@
     "firefoxId": "0ff38d7a-db91-4a1a-a222-00f10d098b22",
     "safariId": "9F9F9D62-DE32-4B4F-88FD-63D448DACFDC"
   }
-}
+]

--- a/browser-extensions.json
+++ b/browser-extensions.json
@@ -1,5 +1,5 @@
-[
-  {
+{
+  "nordpass": {
     "name": "NordPass",
     "message": "NordPass performs polyfill-like transformations on navigator.credentials, affecting tests for the CredentialsContainer API.",
     "affectedTests": ["api.CredentialsContainer"],
@@ -7,4 +7,4 @@
     "firefoxId": "0ff38d7a-db91-4a1a-a222-00f10d098b22",
     "safariId": "9F9F9D62-DE32-4B4F-88FD-63D448DACFDC"
   }
-]
+}

--- a/browser-extensions.json
+++ b/browser-extensions.json
@@ -1,6 +1,5 @@
 [
   {
-    "key": "nordpass",
     "name": "NordPass",
     "message": "NordPass performs polyfill-like transformations on navigator.credentials, affecting tests for the CredentialsContainer API.",
     "affectedTests": ["api.CredentialsContainer"],

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -1747,9 +1747,10 @@
         renderHarnessLink(resultsEl);
 
         // Render code and support for reusable instances
-        var reInstKeys = Object.keys(reusableInstances.__sources);
-        for (var i = 0; i < reInstKeys.length; i++) {
-          renderReInstReportEl(reInstKeys[i], resultsEl);
+        for (var key in reusableInstances.__sources) {
+          if (Object.prototype.hasOwnProperty.call(reusableInstances.__sources, key)) {
+            renderReInstReportEl(reusableInstances.__sources[key], resultsEl);
+          }
         }
 
         // Add divider

--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -1748,7 +1748,12 @@
 
         // Render code and support for reusable instances
         for (var key in reusableInstances.__sources) {
-          if (Object.prototype.hasOwnProperty.call(reusableInstances.__sources, key)) {
+          if (
+            Object.prototype.hasOwnProperty.call(
+              reusableInstances.__sources,
+              key
+            )
+          ) {
             renderReInstReportEl(reusableInstances.__sources[key], resultsEl);
           }
         }

--- a/views/extensioncheck.ejs
+++ b/views/extensioncheck.ejs
@@ -111,13 +111,11 @@ See the LICENSE file for copyright details
         return;
       }
 
-      var extensionsToCheck = Object.keys(extensions);
-      var remaining = extensionsToCheck.length;
+      var remaining = extensions.length;
 
       var foundExtensions = [];
 
-      extensionsToCheck.forEach(function(k) {
-        var extension = extensions[k];
+      extensions.forEach(function(extension) {
         checkExtension(extension, function(result) {
           if (result) {
             foundExtensions.push(k);

--- a/views/extensioncheck.ejs
+++ b/views/extensioncheck.ejs
@@ -111,6 +111,11 @@ See the LICENSE file for copyright details
         return;
       }
 
+      if (!('keys' in Object)) {
+        // A browser that doesn't have Object.keys probably doesn't have extensions
+        return;
+      }
+
       var extensionsToCheck = Object.keys(extensions);
       var remaining = extensionsToCheck.length;
 

--- a/views/extensioncheck.ejs
+++ b/views/extensioncheck.ejs
@@ -111,11 +111,13 @@ See the LICENSE file for copyright details
         return;
       }
 
-      var remaining = extensions.length;
+      var extensionsToCheck = Object.keys(extensions);
+      var remaining = extensionsToCheck.length;
 
       var foundExtensions = [];
 
-      extensions.forEach(function(extension) {
+      extensionsToCheck.forEach(function(k) {
+        var extension = extensions[k];
         checkExtension(extension, function(result) {
           if (result) {
             foundExtensions.push(k);


### PR DESCRIPTION
Fixes https://github.com/openwebdocs/mdn-bcd-collector/issues/2053.

1. Converts `browser-extension.json` to array of objects.
2. Replaces a `Object.keys()` usage with a `for..in` loop.

### Before

<img width="419" alt="image" src="https://github.com/user-attachments/assets/a7a7cdb7-9079-4204-8a42-b14d30b24360" />

### After

<img width="419" alt="image" src="https://github.com/user-attachments/assets/ebe18109-4585-4d8b-af75-f95abab46829" />
