### PR TITLE
Add Atomics.pause, FileSystemObserver, ParentNode.moveBefore

### DIFF
--- a/custom/idl/file-system-api.idl
+++ b/custom/idl/file-system-api.idl
@@ -63,3 +63,27 @@ interface DirectoryEntrySync {};
 partial interface FileSystemDirectoryEntry {
   undefined removeRecursively(VoidFunction successCallback, optional ErrorCallback errorCallback);
 };
+
+
+// Remove when https://github.com/whatwg/fs/pull/165 is merged
+
+dictionary FileSystemObserverObserveOptions { boolean recursive = false; };
+
+callback FileSystemObserverCallback = undefined (sequence<FileSystemChangeRecord> records, FileSystemObserver observer);
+
+[Exposed=(DedicatedWorker,SharedWorker,Window),SecureContext]
+interface FileSystemObserver {
+  constructor(FileSystemObserverCallback callback);  
+  Promise<undefined> observe(FileSystemHandle handle, optional FileSystemObserverObserveOptions options = {});  
+  undefined unobserve(FileSystemHandle handle);  undefined disconnect();
+};
+
+enum FileSystemChangeType {  "appeared",  "disappeared",  "errored",  "modified",  "moved",  "unknown", };
+
+dictionary FileSystemChangeRecord {  
+  required FileSystemHandle root;  
+  FileSystemHandle? changedHandle;  
+  required sequence<DOMString> relativePathComponents;  
+  required FileSystemChangeType type;  
+  sequence<DOMString>? relativePathMovedFrom;
+};

--- a/custom/idl/html.idl
+++ b/custom/idl/html.idl
@@ -279,3 +279,8 @@ partial interface HTMLAnchorElement {
 partial interface HTMLElement {
   attribute HTMLAnchorElement anchorElement;
 };
+
+// Remove when https://github.com/whatwg/dom/pull/1307 is merged
+partial interface mixin ParentNode {
+  [CEReactions] undefined moveBefore(Node node, Node? child);
+};

--- a/custom/js.json
+++ b/custom/js.json
@@ -21,6 +21,11 @@
         ]
       }
     },
+    "Atomics": {
+      "members": {
+        "static": ["pause"]
+      }
+    },
     "DataView": {
       "__comment": "Remove instance members when https://tc39.es/proposal-float16array is merged into the main ECMAScript spec.",
       "members": {


### PR DESCRIPTION
Atomics.pause is not added automatically as it is a TC39 proposal, see issue https://github.com/openwebdocs/mdn-bcd-collector/issues/893 for automating this

FileSystemObserver and ParentNode.moveBefore are shipping in Chrome 133 but the spec PRs have not yet merged 😒 
Adding them to our custom idls in the meantime.