### PR TITLE
Add new ECMAScript additions + dialog closedby

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -144,7 +144,7 @@
     },
     "del": {"attributes": [{"datetime": "dateTime"}, "cite"]},
     "details": {"attributes": ["open"]},
-    "dialog": {"attributes": ["open"]},
+    "dialog": {"attributes": ["open", "closedby"]},
     "dir": {
       "interfaceName": "HTMLDirectoryElement",
       "attributes": ["compact", "align"]

--- a/custom/js.json
+++ b/custom/js.json
@@ -21,6 +21,20 @@
         ]
       }
     },
+    "AsyncDisposableStack": {
+      "__comment": "Remove when https://arai-a.github.io/ecma262-compare/?pr=3000 is merged into the main ECMAScript spec.",
+      "ctor": {},
+      "members": {
+        "instance": [
+          "adopt",
+          "defer",
+          "disposeAsync",
+          "disposed",
+          "move",
+          "use"
+        ]
+      }
+    },
     "Atomics": {
       "members": {
         "static": ["pause"]
@@ -30,6 +44,13 @@
       "__comment": "Remove instance members when https://tc39.es/proposal-float16array is merged into the main ECMAScript spec.",
       "members": {
         "instance": ["getFloat16", "setFloat16"]
+      }
+    },
+    "DisposableStack": {
+      "__comment": "Remove when https://arai-a.github.io/ecma262-compare/?pr=3000 is merged into the main ECMAScript spec.",
+      "ctor": {},
+      "members": {
+        "instance": ["adopt", "defer", "dispose", "disposed", "move", "use"]
       }
     },
     "Error": {
@@ -42,7 +63,8 @@
           "message",
           "name",
           "stack"
-        ]
+        ],
+        "static": ["captureStackTrace", "stackTraceLimit"]
       }
     },
     "Float16Array": {
@@ -56,9 +78,9 @@
       "ctor": {}
     },
     "Math": {
-      "__comment": "Remove instance member when https://tc39.es/proposal-float16array is merged into the main ECMAScript spec.",
+      "__comment": "Remove when https://tc39.es/proposal-float16array and/or https://github.com/tc39/proposal-math-sum are merged into the main ECMAScript spec.",
       "members": {
-        "static": ["f16round"]
+        "static": ["f16round", "sumPrecise"]
       }
     },
     "Promise": {
@@ -82,6 +104,13 @@
       }
     },
     "String": {
+      "members": {"static": ["asyncDispose", "dispose"]}
+    },
+    "SuppressedError": {
+      "__comment": "Remove when https://arai-a.github.io/ecma262-compare/?pr=3000 is merged into the main ECMAScript spec.",
+      "ctor": {}
+    },
+    "Symbol": {
       "members": {"instance": ["contains", "length"]}
     },
     "Uint8Array": {


### PR DESCRIPTION
Unfortunately we don't yet automatically discover new ECMAScript proposals (when not merged into main spec) yet (see https://github.com/openwebdocs/mdn-bcd-collector/issues/893).

HTML attributes are also not discovered automatically. (and we have no issue about it.)

This PR adds things manually.