### PR TITLE
fix(harness): access location via self

### DIFF
--- a/static/resources/harness.js
+++ b/static/resources/harness.js
@@ -48,10 +48,10 @@
   // Set to true for debugging output, and 'full' to include completion logging
   var debugmode =
     "location" in self &&
-    "search" in location &&
-    stringIncludes(location.search, "debug=full")
+    "search" in self.location &&
+    stringIncludes(self.location.search, "debug=full")
       ? "full"
-      : stringIncludes(location.search, "debug=true");
+      : stringIncludes(self.location.search, "debug=true");
 
   /* c8 ignore start */
   // Non-invasive polyfills


### PR DESCRIPTION
This should avoid the following error in Firefox 3.5:

```
Error: location is not defined
Source File: http://mdn-bcd-collector.gooborg.com/resources/harness.js
Line: 54
```