### PR TITLE
Use import attributes instead of import assertions

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -12,7 +12,7 @@ import querystring from "node:querystring";
 import readline from "node:readline";
 
 import fs from "fs-extra";
-import bcd from "@mdn/browser-compat-data" assert {type: "json"};
+import bcd from "@mdn/browser-compat-data" with {type: "json"};
 const bcdBrowsers = bcd.browsers;
 import esMain from "es-main";
 import express, {Request, Response, NextFunction} from "express";

--- a/lib/exporter.ts
+++ b/lib/exporter.ts
@@ -11,7 +11,7 @@ import crypto from "node:crypto";
 
 import slugify from "slugify";
 import stringify from "json-stable-stringify";
-import bcd from "@mdn/browser-compat-data" assert {type: "json"};
+import bcd from "@mdn/browser-compat-data" with {type: "json"};
 const bcdBrowsers = bcd.browsers;
 
 import {parseUA} from "./ua-parser.js";

--- a/lib/filter-versions.ts
+++ b/lib/filter-versions.ts
@@ -6,7 +6,7 @@
 // See the LICENSE file for copyright details
 //
 
-import bcd from "@mdn/browser-compat-data" assert {type: "json"};
+import bcd from "@mdn/browser-compat-data" with {type: "json"};
 
 import type {BrowserStatement, BrowserName} from "@mdn/browser-compat-data";
 

--- a/scripts/selenium.ts
+++ b/scripts/selenium.ts
@@ -19,7 +19,7 @@ import {
   WebDriver,
   WebElement,
 } from "selenium-webdriver";
-import bcd from "@mdn/browser-compat-data" assert {type: "json"};
+import bcd from "@mdn/browser-compat-data" with {type: "json"};
 
 const bcdBrowsers = bcd.browsers;
 import {compare as compareVersions} from "compare-versions";


### PR DESCRIPTION
Since the minimum requirement of Node is v20, we can use import attributes without compatibility issues.
