### PR TITLE
env() and var() removed from custom-property tree

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6340,9 +6340,6 @@ css:
   properties:
     custom-property:
       __test: return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');
-      __additional:
-        var: return CSS.supports('color', 'var(--foo)');
-        env: return CSS.supports('color', 'env(--foo)');
     aspect-ratio: |-
       return bcd.testCSSProperty('aspect-ratio', '16 / 9');
   selectors:


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/25645. This data is no longer under css.properties.custom-property.