### PR TITLE
Improve handling of BCD and results paths in scripts

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -18,7 +18,7 @@ export const BASE_DIR = new URL("..", import.meta.url);
  * Otherwise, it uses the resolved path of "../browser-compat-data" relative to BASE_DIR.
  */
 const _get_bcd_dir = {
-  confirmed_path: null,
+  confirmed_path: "",
   /**
    * Tests a specified path to see if it's a local checkout of mdn/browser-compat-data
    * @param dir The directory to test
@@ -27,7 +27,7 @@ const _get_bcd_dir = {
   try_bcd_dir: (dir) => {
     try {
       const packageJsonFile = fs.readFileSync(`${dir}/package.json`);
-      const packageJson = JSON.parse(packageJsonFile);
+      const packageJson = JSON.parse(packageJsonFile.toString("utf8"));
       if (packageJson.name == "@mdn/browser-compat-data") {
         return true;
       }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -17,9 +17,14 @@ export const BASE_DIR = new URL("..", import.meta.url);
  * If the environment variable BCD_DIR is set, it uses the resolved path of BCD_DIR.
  * Otherwise, it uses the resolved path of "../browser-compat-data" relative to BASE_DIR.
  */
-let _get_bcd_dir = {
+const _get_bcd_dir = {
   confirmed_path: null,
-  try_bcd_dir(dir) {
+  /**
+   * Tests a specified path to see if it's a local checkout of mdn/browser-compat-data
+   * @param dir The directory to test
+   * @returns {boolean} If the directory is a BCD checkout
+   */
+  try_bcd_dir: (dir) => {
     try {
       const packageJsonFile = fs.readFileSync(`${dir}/package.json`);
       const packageJson = JSON.parse(packageJsonFile);
@@ -32,6 +37,11 @@ let _get_bcd_dir = {
       return false;
     }
   },
+  /**
+   * Returns a valid BCD directory path based upon environment variable or relative path, or throws an error if none is found
+   * @returns {string} The BCD path detected
+   * @throws An error if no valid BCD path detected
+   */
   get dir() {
     if (this.confirmed_path) {
       return this.confirmed_path;

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,6 +8,7 @@
 
 import {fileURLToPath} from "node:url";
 import path from "node:path";
+import fs from "node:fs";
 
 export const BASE_DIR = new URL("..", import.meta.url);
 
@@ -16,9 +17,49 @@ export const BASE_DIR = new URL("..", import.meta.url);
  * If the environment variable BCD_DIR is set, it uses the resolved path of BCD_DIR.
  * Otherwise, it uses the resolved path of "../browser-compat-data" relative to BASE_DIR.
  */
-export const BCD_DIR = process.env.BCD_DIR
-  ? path.resolve(process.env.BCD_DIR)
-  : fileURLToPath(new URL("../browser-compat-data", BASE_DIR));
+let _get_bcd_dir = {
+  confirmed_path: null,
+  try_bcd_dir(dir) {
+    try {
+      const packageJsonFile = fs.readFileSync(`${dir}/package.json`);
+      const packageJson = JSON.parse(packageJsonFile);
+      if (packageJson.name == "@mdn/browser-compat-data") {
+        return true;
+      }
+      return false;
+    } catch (e) {
+      // If anything fails, we know that we're not looking at BCD
+      return false;
+    }
+  },
+  get dir() {
+    if (this.confirmed_path) {
+      return this.confirmed_path;
+    }
+
+    // First run: determine the BCD path
+    if (process.env.BCD_DIR) {
+      const env_dir = path.resolve(process.env.BCD_DIR);
+      if (this.try_bcd_dir(env_dir)) {
+        this.confirmed_path = env_dir;
+        return env_dir;
+      }
+    }
+
+    const relative_dir = fileURLToPath(
+      new URL("../browser-compat-data", BASE_DIR),
+    );
+    if (this.try_bcd_dir(relative_dir)) {
+      this.confirmed_path = relative_dir;
+      return relative_dir;
+    }
+
+    throw new Error(
+      "You must have https://github.com/mdn/browser-compat-data locally checked out, and its path defined using the BCD_DIR environment variable.",
+    );
+  },
+};
+export const BCD_DIR = _get_bcd_dir.dir;
 
 /**
  * The directory path where the results are stored.

--- a/scripts/add-new-bcd.ts
+++ b/scripts/add-new-bcd.ts
@@ -15,7 +15,7 @@ import esMain from "es-main";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
-import {BCD_DIR} from "../lib/constants.js";
+import {BCD_DIR, RESULTS_DIR} from "../lib/constants.js";
 import {namespaces as jsNamespaces} from "../test-builder/javascript.js";
 
 import {getMissing} from "./feature-coverage.js";
@@ -272,7 +272,7 @@ if (esMain(import.meta)) {
           describe: "The report files to update from (also accepts folders)",
           type: "string",
           array: true,
-          default: ["../mdn-bcd-results/"],
+          default: [RESULTS_DIR],
         })
         .option("verbose", {
           alias: "v",

--- a/scripts/find-missing-reports.ts
+++ b/scripts/find-missing-reports.ts
@@ -21,7 +21,7 @@ import fs from "fs-extra";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
-import {BCD_DIR} from "../lib/constants.js";
+import {BCD_DIR, RESULTS_DIR} from "../lib/constants.js";
 import filterVersions from "../lib/filter-versions.js";
 import {parseUA} from "../lib/ua-parser.js";
 
@@ -159,7 +159,7 @@ if (esMain(import.meta)) {
           describe: "The report files to update from (also accepts folders)",
           type: "string",
           array: true,
-          default: ["../mdn-bcd-results/"],
+          default: [RESULTS_DIR],
         })
         .option("collector-version", {
           alias: "c",

--- a/scripts/update-bcd.ts
+++ b/scripts/update-bcd.ts
@@ -42,7 +42,7 @@ import {Minimatch} from "minimatch";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
-import {BCD_DIR} from "../lib/constants.js";
+import {BCD_DIR, RESULTS_DIR} from "../lib/constants.js";
 import logger from "../lib/logger.js";
 import {parseUA} from "../lib/ua-parser.js";
 
@@ -1411,7 +1411,7 @@ if (esMain(import.meta)) {
           describe: "The report files to update from (also accepts folders)",
           type: "string",
           array: true,
-          default: ["../mdn-bcd-results/"],
+          default: [RESULTS_DIR],
         })
         .option("path", {
           alias: "p",


### PR DESCRIPTION
This PR performs the following changes:
- **Use RESULTS_DIR constant everywhere**
- **Make sure that BCD path is valid before attempting to use it**

Fixes #2438.
