### PR TITLE
Don't add IE = false when adding new features

### DIFF
--- a/scripts/add-new-bcd.ts
+++ b/scripts/add-new-bcd.ts
@@ -37,7 +37,6 @@ const template = {
       edge: "mirror",
       firefox: {version_added: null},
       firefox_android: "mirror",
-      ie: {version_added: false},
       oculus: "mirror",
       opera: "mirror",
       opera_android: "mirror",


### PR DESCRIPTION
Following an update to BCD that does this automatically at build time.
