### PR TITLE
Correctly move symbol_as_target

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6863,7 +6863,7 @@ javascript:
             var e = new Error('foo', {cause: 'testing'});
             return e.cause === 'testing';
     FinalizationRegistry:
-      FinalizationRegistry:
+      register:
         __additional:
           symbol_as_target: |-
             try {


### PR DESCRIPTION
https://github.com/openwebdocs/mdn-bcd-collector/pull/2370 wrongly moved this under FinalizationRegistry.FinalizationRegistry but BCD has it under FinalizationRegistry.register.