### PR TITLE
Turn directory constants into getter functions

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,69 +13,83 @@ import fs from "node:fs";
 export const BASE_DIR = new URL("..", import.meta.url);
 
 /**
+ * Tests a specified path to see if it's a local checkout of mdn/browser-compat-data
+ * @param dir The directory to test
+ * @returns {boolean} If the directory is a BCD checkout
+ */
+const try_bcd_dir = (dir) => {
+  try {
+    const packageJsonFile = fs.readFileSync(`${dir}/package.json`);
+    const packageJson = JSON.parse(packageJsonFile.toString("utf8"));
+    if (packageJson.name == "@mdn/browser-compat-data") {
+      return true;
+    }
+    return false;
+  } catch (e) {
+    // If anything fails, we know that we're not looking at BCD
+    return false;
+  }
+};
+
+/**
+ * Tests a specified path to see if it's a local checkout of mdn-bcd-results
+ * @param dir The directory to test
+ * @returns {boolean} If the directory is a mdn-bcd-results checkout
+ */
+const try_results_dir = (dir) => {
+  try {
+    return fs.existsSync(`${dir}/README.md`);
+  } catch (e) {
+    // If anything fails, we know that we're not looking at mdn-bcd-results
+    return false;
+  }
+};
+
+/**
+ * Returns a valid directory path based upon environment variable or relative path and a checker function, or throws an error if none is found
+ * @returns {string} The BCD path detected
+ * @throws An error if no valid BCD path detected
+ */
+const get_dir = (env_variable, relative_path, github_url, try_func) => {
+  if (process.env[env_variable]) {
+    const env_dir = path.resolve(process.env[env_variable]);
+    if (try_func(env_dir)) {
+      return env_dir;
+    }
+  }
+
+  const relative_dir = fileURLToPath(new URL(relative_path, BASE_DIR));
+  if (try_func(relative_dir)) {
+    return relative_dir;
+  }
+
+  throw new Error(
+    `You must have ${github_url} locally checked out, and its path defined using the ${env_variable} environment variable.`,
+  );
+};
+
+/**
  * The directory path for the Browser Compatibility Data (BCD) repository.
  * If the environment variable BCD_DIR is set, it uses the resolved path of BCD_DIR.
  * Otherwise, it uses the resolved path of "../browser-compat-data" relative to BASE_DIR.
  */
-const _get_bcd_dir = {
-  confirmed_path: "",
-  /**
-   * Tests a specified path to see if it's a local checkout of mdn/browser-compat-data
-   * @param dir The directory to test
-   * @returns {boolean} If the directory is a BCD checkout
-   */
-  try_bcd_dir: (dir) => {
-    try {
-      const packageJsonFile = fs.readFileSync(`${dir}/package.json`);
-      const packageJson = JSON.parse(packageJsonFile.toString("utf8"));
-      if (packageJson.name == "@mdn/browser-compat-data") {
-        return true;
-      }
-      return false;
-    } catch (e) {
-      // If anything fails, we know that we're not looking at BCD
-      return false;
-    }
-  },
-  /**
-   * Returns a valid BCD directory path based upon environment variable or relative path, or throws an error if none is found
-   * @returns {string} The BCD path detected
-   * @throws An error if no valid BCD path detected
-   */
-  get dir() {
-    if (this.confirmed_path) {
-      return this.confirmed_path;
-    }
-
-    // First run: determine the BCD path
-    if (process.env.BCD_DIR) {
-      const env_dir = path.resolve(process.env.BCD_DIR);
-      if (this.try_bcd_dir(env_dir)) {
-        this.confirmed_path = env_dir;
-        return env_dir;
-      }
-    }
-
-    const relative_dir = fileURLToPath(
-      new URL("../browser-compat-data", BASE_DIR),
-    );
-    if (this.try_bcd_dir(relative_dir)) {
-      this.confirmed_path = relative_dir;
-      return relative_dir;
-    }
-
-    throw new Error(
-      "You must have https://github.com/mdn/browser-compat-data locally checked out, and its path defined using the BCD_DIR environment variable.",
-    );
-  },
-};
-export const BCD_DIR = _get_bcd_dir.dir;
+export const getBCDDir = () =>
+  get_dir(
+    "BCD_DIR",
+    "../browser-compat-data",
+    "https://github.com/mdn/browser-compat-data",
+    try_bcd_dir,
+  );
 
 /**
  * The directory path where the results are stored.
  * If the RESULTS_DIR environment variable is set, it will be used.
  * Otherwise, the default path is resolved relative to the BASE_DIR.
  */
-export const RESULTS_DIR = process.env.RESULTS_DIR
-  ? path.resolve(process.env.RESULTS_DIR)
-  : fileURLToPath(new URL("../mdn-bcd-results", BASE_DIR));
+export const getResultsDir = () =>
+  get_dir(
+    "RESULTS_DIR",
+    "../mdn-bcd-results",
+    "https://github.com/openwebdocs/mdn-bcd-results",
+    try_results_dir,
+  );

--- a/scripts/add-new-bcd.ts
+++ b/scripts/add-new-bcd.ts
@@ -15,11 +15,14 @@ import esMain from "es-main";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
-import {BCD_DIR, RESULTS_DIR} from "../lib/constants.js";
+import {getBCDDir, getResultsDir} from "../lib/constants.js";
 import {namespaces as jsNamespaces} from "../test-builder/javascript.js";
 
 import {getMissing} from "./feature-coverage.js";
 import {main as updateBcd} from "./update-bcd.js";
+
+const BCD_DIR = getBCDDir();
+const RESULTS_DIR = getResultsDir();
 
 const tests = await fs.readJson(new URL("../tests.json", import.meta.url));
 const overrides = await fs.readJson(

--- a/scripts/feature-coverage.ts
+++ b/scripts/feature-coverage.ts
@@ -19,7 +19,9 @@ import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
 import {Tests} from "../types/types.js";
-import {BCD_DIR} from "../lib/constants.js";
+import {getBCDDir} from "../lib/constants.js";
+
+const BCD_DIR = getBCDDir();
 
 const untestableFeatures = jsonc.parse(
   await fs.readFile(

--- a/scripts/find-missing-reports.ts
+++ b/scripts/find-missing-reports.ts
@@ -21,13 +21,16 @@ import fs from "fs-extra";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
-import {BCD_DIR, RESULTS_DIR} from "../lib/constants.js";
+import {getBCDDir, getResultsDir} from "../lib/constants.js";
 import filterVersions from "../lib/filter-versions.js";
 import {parseUA} from "../lib/ua-parser.js";
 
 import {loadJsonFiles} from "./update-bcd.js";
 
 import type {BrowserName} from "@mdn/browser-compat-data";
+
+const BCD_DIR = getBCDDir();
+const RESULTS_DIR = getResultsDir();
 
 const {default: bcd}: {default: CompatData} = await import(
   `${BCD_DIR}/index.js`

--- a/scripts/report-stats.ts
+++ b/scripts/report-stats.ts
@@ -17,10 +17,12 @@ import {hideBin} from "yargs/helpers";
 import {CompatData} from "@mdn/browser-compat-data/types";
 
 import {Report, ReportStats} from "../types/types.js";
-import {BCD_DIR} from "../lib/constants.js";
+import {getBCDDir} from "../lib/constants.js";
 import {parseUA} from "../lib/ua-parser.js";
 
 import {findMissing} from "./feature-coverage.js";
+
+const BCD_DIR = getBCDDir();
 
 const {default: bcd}: {default: CompatData} = await import(
   `${BCD_DIR}/index.js`

--- a/scripts/selenium.ts
+++ b/scripts/selenium.ts
@@ -31,13 +31,15 @@ import {Listr, ListrTask, ListrTaskWrapper} from "listr2";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
-import {RESULTS_DIR} from "../lib/constants.js";
+import {getResultsDir} from "../lib/constants.js";
 import filterVersionsLib from "../lib/filter-versions.js";
 import getSecrets from "../lib/secrets.js";
 
 import type {BrowserName} from "@mdn/browser-compat-data";
 
 import "../lib/selenium-keepalive.js";
+
+const RESULTS_DIR = getResultsDir();
 
 type Task = ListrTaskWrapper<any, any, any>;
 

--- a/scripts/update-bcd.ts
+++ b/scripts/update-bcd.ts
@@ -42,9 +42,12 @@ import {Minimatch} from "minimatch";
 import yargs from "yargs";
 import {hideBin} from "yargs/helpers";
 
-import {BCD_DIR, RESULTS_DIR} from "../lib/constants.js";
+import {getBCDDir, getResultsDir} from "../lib/constants.js";
 import logger from "../lib/logger.js";
 import {parseUA} from "../lib/ua-parser.js";
+
+const BCD_DIR = getBCDDir();
+const RESULTS_DIR = getResultsDir();
 
 const {default: mirror} = await import(`${BCD_DIR}/scripts/build/mirror.js`);
 


### PR DESCRIPTION
Since the invisible getter isn't working, this converts both of the directory constants into getter functions and combines their logic.
