### PR TITLE
*draft* Support Bun with patch changes

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 import fs from "node:fs";
 
 export const BASE_DIR = new URL("..", import.meta.url);
+export const RUNTIME_IDS_WITH_PATCH_VERSIONING = new Set(["bun"]); // List of browsers/runtimes that might add features in patches
 
 /**
  * Tests a specified path to see if it's a local checkout of mdn/browser-compat-data

--- a/lib/ua-parser.test.ts
+++ b/lib/ua-parser.test.ts
@@ -11,6 +11,7 @@ import {assert} from "chai";
 import {getMajorMinorVersion, parseUA} from "./ua-parser.js";
 
 const browsers = {
+  bun: {name: "Bun", releases: {"1.0.0": {}, "1.1.15": {}, "1.2.0": {}}},
   chrome: {name: "Chrome", releases: {82: {}, 83: {}, 84: {}, 85: {}}},
   chrome_android: {name: "Chrome Android", releases: {85: {}}},
   deno: {name: "Deno", releases: {1.42: {}}},
@@ -519,6 +520,46 @@ describe("parseUA", () => {
       fullVersion: "1.42",
       os: {name: "", version: ""},
       inBcd: true,
+    });
+  });
+
+  it("Bun 1.0.0 (preserves patch version)", () => {
+    assert.deepEqual(parseUA("!! bun/1.0.0", browsers), {
+      browser: {id: "bun", name: "Bun"},
+      version: "1.0.0",
+      fullVersion: "1.0.0",
+      os: {name: "", version: ""},
+      inBcd: true,
+    });
+  });
+
+  it("Bun 1.1.15 (preserves patch version)", () => {
+    assert.deepEqual(parseUA("!! bun/1.1.15", browsers), {
+      browser: {id: "bun", name: "Bun"},
+      version: "1.1.15",
+      fullVersion: "1.1.15",
+      os: {name: "", version: ""},
+      inBcd: true,
+    });
+  });
+
+  it("Bun 1.2.0 (preserves patch version)", () => {
+    assert.deepEqual(parseUA("!! bun/1.2.0", browsers), {
+      browser: {id: "bun", name: "Bun"},
+      version: "1.2.0",
+      fullVersion: "1.2.0",
+      os: {name: "", version: ""},
+      inBcd: true,
+    });
+  });
+
+  it("Bun 1.1.16 (not in BCD)", () => {
+    assert.deepEqual(parseUA("!! bun/1.1.16", browsers), {
+      browser: {id: "bun", name: "Bun"},
+      version: "1.1.16",
+      fullVersion: "1.1.16",
+      os: {name: "", version: ""},
+      inBcd: false,
     });
   });
 

--- a/lib/ua-parser.ts
+++ b/lib/ua-parser.ts
@@ -13,6 +13,7 @@ import {
 } from "compare-versions";
 import {UAParser} from "ua-parser-js";
 import {ParsedUserAgent} from "../types/types";
+import {RUNTIME_IDS_WITH_PATCH_VERSIONING} from "./constants";
 
 /**
  * Returns the major version from a given version string.
@@ -110,7 +111,12 @@ const parseUA = (userAgent: string, browsers: Browsers): ParsedUserAgent => {
   }
 
   data.fullVersion = data.fullVersion || ua.browser.version || "0";
-  data.version = getMajorMinorVersion(data.fullVersion);
+
+  if (RUNTIME_IDS_WITH_PATCH_VERSIONING.has(data.browser.id)) {
+    data.version = data.fullVersion;
+  } else {
+    data.version = getMajorMinorVersion(data.fullVersion);
+  }
 
   if (!(data.browser.id in browsers)) {
     return data;
@@ -150,16 +156,24 @@ const parseUA = (userAgent: string, browsers: Browsers): ParsedUserAgent => {
   // with this, find the pair of versions in |versions| that sandwiches
   // |version|, and use the first of this pair. For example, given |version|
   // "10.1" and |versions| entries "10.0" and "10.2", return "10.0".
-  for (let i = 0; i < versions.length - 1; i++) {
-    const current = versions[i];
-    const next = versions[i + 1];
-    if (
-      compareVersions(data.version, current, ">=") &&
-      compareVersions(data.version, next, "<")
-    ) {
+  // However, for Bun, we need exact version matches because patch versions can add features.
+  if (RUNTIME_IDS_WITH_PATCH_VERSIONING.has(data.browser.id)) {
+    // For Bun, only mark as inBcd if exact version exists
+    if (versions.includes(data.version)) {
       data.inBcd = true;
-      data.version = current;
-      break;
+    }
+  } else {
+    for (let i = 0; i < versions.length - 1; i++) {
+      const current = versions[i];
+      const next = versions[i + 1];
+      if (
+        compareVersions(data.version, current, ">=") &&
+        compareVersions(data.version, next, "<")
+      ) {
+        data.inBcd = true;
+        data.version = current;
+        break;
+      }
     }
   }
 
@@ -167,19 +181,21 @@ const parseUA = (userAgent: string, browsers: Browsers): ParsedUserAgent => {
   // we have to check if it looks like a significant release or not. By default
   // that means a new major version, but for Safari and Samsung Internet the
   // major and minor version are significant.
-  let normalize = getMajorVersion;
-  if (
-    data.browser.id.startsWith("safari") ||
-    data.browser.id === "samsunginternet_android"
-  ) {
-    normalize = getMajorMinorVersion;
-  }
-  if (
-    data.inBcd == false &&
-    normalize(data.version) === normalize(versions[versions.length - 1])
-  ) {
-    data.inBcd = true;
-    data.version = versions[versions.length - 1];
+  if (!RUNTIME_IDS_WITH_PATCH_VERSIONING.has(data.browser.id)) {
+    let normalize = getMajorVersion;
+    if (
+      data.browser.id.startsWith("safari") ||
+      data.browser.id === "samsunginternet_android"
+    ) {
+      normalize = getMajorMinorVersion;
+    }
+    if (
+      data.inBcd == false &&
+      normalize(data.version) === normalize(versions[versions.length - 1])
+    ) {
+      data.inBcd = true;
+      data.version = versions[versions.length - 1];
+    }
   }
 
   return data;

--- a/scripts/find-missing-reports.ts
+++ b/scripts/find-missing-reports.ts
@@ -50,7 +50,7 @@ const generateReportMap = (filter: string) => {
   for (const browser of Object.keys(browsers)) {
     if (
       filter !== "all" &&
-      ["ie", "nodejs", "deno", "oculus"].includes(browser)
+      ["ie", "nodejs", "deno", "bun", "oculus"].includes(browser)
     ) {
       continue;
     }


### PR DESCRIPTION
Work in progress to support collecting Bun's versions in MDN. These changes are necessary because Bun can add new features in semver patches, which would be important and relevant for BCD to collect.