### PR TITLE
Remove <textarea spellcheck>

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -460,7 +460,6 @@
         "placeholder",
         "required",
         "rows",
-        "spellcheck",
         "wrap"
       ]
     },


### PR DESCRIPTION
It is a global attribute instead. See https://github.com/mdn/browser-compat-data/pull/26764