### PR TITLE
Remove unneeded 'only' entries

### DIFF
--- a/custom/css.json
+++ b/custom/css.json
@@ -220,12 +220,6 @@
     "color-interpolation": {
       "__values": ["linearGradient", "sRGB"]
     },
-    "color-scheme": {
-      "__additional_values": {
-        "only_dark": "only dark",
-        "only_light": "only light"
-      }
-    },
     "column-progression": {},
     "contain-intrinsic-size": {
       "__additional_values": {


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/27480.

Currently, the collector proposes to add "only" to BCD (via webref) which we should do. These two extra entries aren't needed then.