### PR TITLE
Bump typescript-eslint with Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "selenium-webdriver": "4.34.0",
         "sinon": "21.0.0",
         "typescript": "5.9.2",
-        "typescript-eslint": "^8.38.0",
+        "typescript-eslint": "~8.39.0",
         "webidl2": "24.5.0",
         "yaml": "2.8.0"
       },

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "selenium-webdriver": "4.34.0",
     "sinon": "21.0.0",
     "typescript": "5.9.2",
-    "typescript-eslint": "^8.38.0",
+    "typescript-eslint": "~8.39.0",
     "webidl2": "24.5.0",
     "yaml": "2.8.0"
   }


### PR DESCRIPTION
Quick little update to make sure that Dependabot updates `typescript-eslint`, which is important when TypeScript itself gets an update.
