### PR TITLE
Upgrade TypeScript module resolution to NodeNext

### DIFF
--- a/lib/exporter.ts
+++ b/lib/exporter.ts
@@ -41,10 +41,11 @@ const getReportMeta = (report: Report): ReportMeta => {
   const os = `${ua.os.name} ${ua.os.version}`;
   const desc = `${browser} / ${os}`;
 
+  // XXX Casting slugify to "any" to mitigate NodeNext module resolution issue
   const slug = `${report.__version.toLowerCase()}-${ua.browser.id.replace(
     /_/g,
     "-",
-  )}-${ua.fullVersion}-${slugify(os, {lower: true})}-${digest}`;
+  )}-${ua.fullVersion}-${(slugify as any)(os, {lower: true})}-${digest}`;
 
   return {
     json,

--- a/lib/secrets.ts
+++ b/lib/secrets.ts
@@ -7,7 +7,8 @@
 //
 
 import fs from "fs-extra";
-import {Secrets} from "../types/types";
+
+import type {Secrets} from "../types/types.d.ts";
 
 /**
  * Retrieves the secrets based on the current environment.

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -10,7 +10,8 @@ import assert from "node:assert/strict";
 
 import fs from "fs-extra";
 import {Storage as GAEStorage, Bucket} from "@google-cloud/storage";
-import {Extensions, ReportStore, TestResult} from "../types/types";
+
+import type {Extensions, ReportStore, TestResult} from "../types/types.d.ts";
 
 /**
  * Represents a base storage class for storing and retrieving data.

--- a/lib/ua-parser.ts
+++ b/lib/ua-parser.ts
@@ -12,7 +12,8 @@ import {
   compareVersions as compareVersionsSort,
 } from "compare-versions";
 import {UAParser} from "ua-parser-js";
-import {ParsedUserAgent} from "../types/types";
+
+import type {ParsedUserAgent} from "../types/types.d.ts";
 
 /**
  * Returns the major version from a given version string.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "noImplicitAny": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
Apparently, the `node` module resolution was meant for Node v10 and below!
