### PR TITLE
Potential fix for code scanning alert no. 7: Client-side cross-site scripting

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -37,7 +37,7 @@ See the LICENSE file for copyright details
     </div>
     <% if (selenium) { %>
       <input id="selenium" name="selenium" type="hidden" value="true">
-      <input id="ignore" name="ignore" type="hidden" value="<%-ignore%>">
+      <input id="ignore" name="ignore" type="hidden" value="<%=ignore%>">
     <% } %>
   </form>
   <%- include('unsecurewarning') %>


### PR DESCRIPTION
Potential fix for [https://github.com/openwebdocs/mdn-bcd-collector/security/code-scanning/7](https://github.com/openwebdocs/mdn-bcd-collector/security/code-scanning/7)

The best way to fix this problem is to ensure the value of `ignore` is not injected into HTML unescaped. In EJS, using `<%= ... %>` instead of `<%- ... %>` escapes the content for safe HTML embedding, preventing characters like double quotes, angle brackets, etc., from breaking out of the value attribute and being interpreted as markup or script. Thus, you should change line 40 in views/index.ejs from `<input id="ignore" name="ignore" type="hidden" value="<%-ignore%>">` to `<input id="ignore" name="ignore" type="hidden" value="<%=ignore%>">`. This maintains existing functionality but ensures user-provided data is properly escaped.

Only one file (views/index.ejs) requires an update, specifically a change on line 40. No new methods or imports are needed, and no package installations are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
