### PR TITLE
Add custom test for HTML `<input switch>`

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -274,7 +274,8 @@
         "pattern",
         "placeholder",
         "src",
-        "step"
+        "step",
+        "switch"
       ]
     },
     "ins": {"attributes": [{"datetime": "dateTime"}, "cite"]},


### PR DESCRIPTION
Related to https://github.com/mdn/browser-compat-data/issues/28896.

Passes in Safari:

<img width="598" height="316" alt="image" src="https://github.com/user-attachments/assets/b005b0d1-9cd4-4c12-bdfc-697ab189a675" />
