### PR TITLE
Dependabot groups: data and dev

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,12 @@ updates:
     schedule:
       interval: daily
     groups:
-      listr2:
+      data:
         patterns:
-          - "listr2"
-          - "@listr2/*"
+          - "@webref/*"
+      dev:
+        exclude-patterns:
+          - "@webref/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Not sure if what I am doing here is correct but I think it would be good to have a group for all dev dependencies and then one for the webref data updates.