### PR TITLE
Remove hreftranslate tests

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -33,8 +33,7 @@
     "a": {
       "attributes": [
         {
-          "referrerpolicy": "referrerPolicy",
-          "hreftranslate": "hrefTranslate"
+          "referrerpolicy": "referrerPolicy"
         },
         "charset",
         "coords",

--- a/custom/idl/html.idl
+++ b/custom/idl/html.idl
@@ -233,13 +233,6 @@ partial interface HTMLMediaElement {
   readonly attribute boolean allowedToPlay;
 };
 
-// Proposed addition to HTML (implemented in Chrome)
-// https://github.com/whatwg/html/pull/3870
-// https://github.com/mdn/browser-compat-data/issues/21898
-partial interface HTMLAnchorElement {
-  [CEReactions]attribute DOMString hrefTranslate;
-};
-
 // Non-standard
 
 partial interface HTMLElement {


### PR DESCRIPTION
This always tries to update the compat data from 81 to the latest version. Not sure why it is doing that but I'm just going to remove the tests for this as it is non-standard, see https://github.com/mdn/browser-compat-data/pull/25863