### PR TITLE
Fix test for CSS sign() type

### DIFF
--- a/custom/css.json
+++ b/custom/css.json
@@ -1315,8 +1315,8 @@
     },
     "sign": {
       "syntax": "<sign()>",
-      "property": "top",
-      "value": "sign(20vh - 100px)"
+      "property": "aspect-ratio",
+      "value": "sign(1rem - 1px)"
     },
     "sin": {
       "syntax": "<sin()>",


### PR DESCRIPTION
Seems like this would actually be meaningful to CSS.supports()