### PR TITLE
Unignore GlobalEventHandlers + WindowEventHandlers

### DIFF
--- a/custom/idl/event-handlers.idl
+++ b/custom/idl/event-handlers.idl
@@ -1,122 +1,26 @@
 partial interface Document {
-  attribute EventHandler onscroll;
-  attribute EventHandler onscrollend;
   attribute EventHandler onscrollsnapchange;
   attribute EventHandler onscrollsnapchanging;
-  attribute EventHandler onsecuritypolicyviolation;
-  attribute EventHandler onselectionchange;
 };
 
-partial interface Element {
+partial interface HTMLElement {
   attribute EventHandler onafterscriptexecute;
-  attribute EventHandler onanimationcancel;
-  attribute EventHandler onanimationend;
-  attribute EventHandler onanimationiteration;
-  attribute EventHandler onanimationstart;
-  attribute EventHandler onauxclick;
-  attribute EventHandler onbeforeinput;
-  attribute EventHandler onbeforematch;
   attribute EventHandler onbeforescriptexecute;
-  attribute EventHandler onbeforexrselect;
-  attribute EventHandler onblur;
-  attribute EventHandler onclick;
   attribute EventHandler oncompositionend;
   attribute EventHandler oncompositionstart;
   attribute EventHandler oncompositionupdate;
   attribute EventHandler oncontentvisibilityautostatechange;
-  attribute EventHandler oncontextmenu;
-  attribute EventHandler oncopy;
-  attribute EventHandler oncut;
-  attribute EventHandler ondblclick;
-  attribute EventHandler onfocus;
-  attribute EventHandler ongotpointercapture;
-  attribute EventHandler oninput;
-  attribute EventHandler onkeydown;
-  attribute EventHandler onkeypress;
-  attribute EventHandler onkeyup;
-  attribute EventHandler onlostpointercapture;
-  attribute EventHandler onmousedown;
-  attribute EventHandler onmouseenter;
-  attribute EventHandler onmouseleave;
-  attribute EventHandler onmousemove;
-  attribute EventHandler onmouseout;
-  attribute EventHandler onmouseover;
-  attribute EventHandler onmouseup;
-  attribute EventHandler onmousewheel;
-  attribute EventHandler onpaste;
-  attribute EventHandler onpointercancel;
-  attribute EventHandler onpointerdown;
-  attribute EventHandler onpointerenter;
-  attribute EventHandler onpointerleave;
-  attribute EventHandler onpointermove;
-  attribute EventHandler onpointerout;
-  attribute EventHandler onpointerover;
-  attribute EventHandler onpointerrawupdate;
-  attribute EventHandler onpointerup;
-  attribute EventHandler onscroll;
-  attribute EventHandler onscrollend;
   attribute EventHandler onscrollsnapchange;
   attribute EventHandler onscrollsnapchanging;
-  attribute EventHandler onsecuritypolicyviolation;
-  attribute EventHandler ontouchcancel;
-  attribute EventHandler ontouchend;
-  attribute EventHandler ontouchmove;
-  attribute EventHandler ontouchstart;
-  attribute EventHandler ontransitioncancel;
-  attribute EventHandler ontransitionend;
-  attribute EventHandler ontransitionrun;
-  attribute EventHandler ontransitionstart;
   attribute EventHandler onwebkitmouseforcechanged;
   attribute EventHandler onwebkitmouseforcedown;
   attribute EventHandler onwebkitmouseforceup;
   attribute EventHandler onwebkitmouseforcewillbegin;
-  attribute EventHandler onwheel;
 };
 
 partial interface Window {
-  attribute EventHandler onafterprint;
-  attribute EventHandler onbeforeprint;
-  attribute EventHandler onbeforeunload;
-  attribute EventHandler onblur;
-  attribute EventHandler onerror;
-  attribute EventHandler onfocus;
-  attribute EventHandler ongamepadconnected;
-  attribute EventHandler ongamepaddisconnected;
-  attribute EventHandler onhashchange;
-  attribute EventHandler onlanguagechange;
-  attribute EventHandler onload;
-  attribute EventHandler onmessage;
-  attribute EventHandler onmessageerror;
-  attribute EventHandler onoffline;
-  attribute EventHandler ononline;
-  attribute EventHandler onpagehide;
-  attribute EventHandler onpagereveal;
-  attribute EventHandler onpageshow;
-  attribute EventHandler onpageswap;
-  attribute EventHandler onpopstate;
-  attribute EventHandler onrejectionhandled;
-  attribute EventHandler onresize;
   attribute EventHandler onscrollsnapchange;
   attribute EventHandler onscrollsnapchanging;
-  attribute EventHandler onstorage;
-  attribute EventHandler onunhandledrejection;
-  attribute EventHandler onunload;
-};
-
-partial interface HTMLElement {
-  attribute EventHandler onbeforetoggle;
-  attribute EventHandler onchange;
-  attribute EventHandler oncommand;
-  attribute EventHandler ondrag;
-  attribute EventHandler ondragend;
-  attribute EventHandler ondragenter;
-  attribute EventHandler ondragexit;
-  attribute EventHandler ondragleave;
-  attribute EventHandler ondragover;
-  attribute EventHandler ondragstart;
-  attribute EventHandler ondrop;
-  attribute EventHandler onerror;
-  attribute EventHandler ontoggle;
 };
 
 partial interface HTMLCanvasElement {
@@ -194,11 +98,6 @@ partial interface SVGAnimationElement {
   attribute EventHandler onbeginEvent;
   attribute EventHandler onendEvent;
   attribute EventHandler onrepeatEvent;
-};
-
-partial interface SVGElement {
-  attribute EventHandler onerror;
-  attribute EventHandler onload;
 };
 
 partial interface WorkerGlobalScope {

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -1658,7 +1658,7 @@ api:
     __base: |-
       var instance;
       try {
-        instance = document.createElementNS('http://www.w3.org/1999/xhtml', 'el');
+        instance = document.createElementNS('', 'el');
       } catch(e) {
         instance = document.createElement('b');
       }

--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -1658,7 +1658,7 @@ api:
     __base: |-
       var instance;
       try {
-        instance = document.createElementNS('', 'el');
+        instance = document.createElementNS('http://www.w3.org/1999/xhtml', 'el');
       } catch(e) {
         instance = document.createElement('b');
       }

--- a/test-builder/api.ts
+++ b/test-builder/api.ts
@@ -94,8 +94,6 @@ const flattenIDL = (specIDLs: IDLFiles, customIDLs: IDLFiles) => {
     if (dfn.type === "includes") {
       const skipIncludes = [
         "WindowOrWorkerGlobalScope", // handled separately as globals
-        "GlobalEventHandlers", // XXX needs special handling
-        "WindowEventHandlers", // XXX needs special handling
       ];
       if (skipIncludes.includes(dfn.includes)) {
         continue;


### PR DESCRIPTION
Triggered by https://github.com/mdn/browser-compat-data/issues/29376.

### Summary

This change adds 546 features across 8 interfaces, and removes 63 features.

```diff
# api.Element (63 removed)
-afterscriptexecute
-animationcancel
-animationend
-animationiteration
-animationstart
-auxclick
-beforeinput
-beforematch
-beforescriptexecute
-beforexrselect
-blur
-click
-compositionend
-compositionstart
-compositionupdate
-contentvisibilityautostatechange
-contextmenu
-copy
-cut
-dblclick
-focus
-gotpointercapture
-input
-keydown
-keypress
-keyup
-lostpointercapture
-mousedown
-mouseenter
-mouseleave
-mousemove
-mouseout
-mouseover
-mouseup
-mousewheel
-paste
-pointercancel
-pointerdown
-pointerenter
-pointerleave
-pointermove
-pointerout
-pointerover
-pointerrawupdate
-pointerup
-scroll
-scrollend
-scrollsnapchange
-scrollsnapchanging
-securitypolicyviolation
-touchcancel
-touchend
-touchmove
-touchstart
-transitioncancel
-transitionend
-transitionrun
-transitionstart
-webkitmouseforcechanged
-webkitmouseforcedown
-webkitmouseforceup
-webkitmouseforcewillbegin
-wheel
```

```diff
# api.Document (106 added)
+abort
+animationcancel
+animationend
+animationiteration
+animationstart
+auxclick
+beforeinput
+beforematch
+beforetoggle
+beforexrselect
+blur
+cancel
+canplay
+canplaythrough
+change
+click
+close
+command
+contextlost
+contextmenu
+contextrestored
+copy
+cuechange
+cut
+dblclick
+drag
+dragend
+dragenter
+dragexit
+dragleave
+dragover
+dragstart
+drop
+durationchange
+emptied
+ended
+error
+fencedtreeclick
+focus
+formdata
+gotpointercapture
+input
+invalid
+keydown
+keypress
+keyup
+load
+loadeddata
+loadedmetadata
+loadend
+loadstart
+lostpointercapture
+mousedown
+mouseenter
+mouseleave
+mousemove
+mouseout
+mouseover
+mouseup
+mousewheel
+paste
+pause
+play
+playing
+pointercancel
+pointerdown
+pointerenter
+pointerleave
+pointermove
+pointerout
+pointerover
+pointerrawupdate
+pointerup
+progress
+ratechange
+reset
+resize
+search
+seeked
+seeking
+select
+selectstart
+slotchange
+snapchanged
+snapchanging
+stalled
+submit
+suspend
+timeupdate
+toggle
+touchcancel
+touchend
+touchforcechange
+touchmove
+touchstart
+transitioncancel
+transitionend
+transitionrun
+transitionstart
+volumechange
+waiting
+webkitanimationend
+webkitanimationiteration
+webkitanimationstart
+webkittransitionend
+wheel
```

```diff
# api.Window (50 added)
+paste
+pause
+play
+playing
+pointercancel
+pointerdown
+pointerenter
+pointerleave
+pointermove
+pointerout
+pointerover
+pointerrawupdate
+pointerup
+portalactivate
+progress
+ratechange
+reset
+scroll
+scrollend
+search
+securitypolicyviolation
+seeked
+seeking
+select
+selectionchange
+selectstart
+slotchange
+snapchanged
+snapchanging
+stalled
+submit
+suspend
+timeupdate
+toggle
+touchcancel
+touchend
+touchforcechange
+touchmove
+touchstart
+transitioncancel
+transitionend
+transitionrun
+transitionstart
+volumechange
+waiting
+webkitanimationend
+webkitanimationiteration
+webkitanimationstart
+webkittransitionend
+wheel
```

```diff
# api.HTMLBodyElement (21 added)
+afterprint
+beforeprint
+beforeunload
+gamepadconnected
+gamepaddisconnected
+hashchange
+languagechange
+message
+messageerror
+offline
+online
+pagehide
+pagereveal
+pageshow
+pageswap
+popstate
+portalactivate
+rejectionhandled
+storage
+unhandledrejection
+unload
```

```diff
# api.HTMLElement (109 added)
+abort
+afterscriptexecute
+animationcancel
+animationend
+animationiteration
+animationstart
+auxclick
+beforeinput
+beforematch
+beforescriptexecute
+beforexrselect
+blur
+cancel
+canplay
+canplaythrough
+click
+close
+compositionend
+compositionstart
+compositionupdate
+contentvisibilityautostatechange
+contextlost
+contextmenu
+contextrestored
+copy
+cuechange
+cut
+dblclick
+durationchange
+emptied
+ended
+fencedtreeclick
+focus
+formdata
+gotpointercapture
+input
+invalid
+keydown
+keypress
+keyup
+load
+loadeddata
+loadedmetadata
+loadend
+loadstart
+lostpointercapture
+mousedown
+mouseenter
+mouseleave
+mousemove
+mouseout
+mouseover
+mouseup
+mousewheel
+paste
+pause
+play
+playing
+pointercancel
+pointerdown
+pointerenter
+pointerleave
+pointermove
+pointerout
+pointerover
+pointerrawupdate
+pointerup
+progress
+ratechange
+reset
+resize
+scroll
+scrollend
+scrollsnapchange
+scrollsnapchanging
+search
+securitypolicyviolation
+seeked
+seeking
+select
+selectionchange
+selectstart
+slotchange
+snapchanged
+snapchanging
+stalled
+submit
+suspend
+timeupdate
+touchcancel
+touchend
+touchforcechange
+touchmove
+touchstart
+transitioncancel
+transitionend
+transitionrun
+transitionstart
+volumechange
+waiting
+webkitanimationend
+webkitanimationiteration
+webkitanimationstart
+webkitmouseforcechanged
+webkitmouseforcedown
+webkitmouseforceup
+webkitmouseforcewillbegin
+webkittransitionend
+wheel
```

```diff
# api.HTMLFrameSetElement (21 added)
+afterprint
+beforeprint
+beforeunload
+gamepadconnected
+gamepaddisconnected
+hashchange
+languagechange
+message
+messageerror
+offline
+online
+pagehide
+pagereveal
+pageshow
+pageswap
+popstate
+portalactivate
+rejectionhandled
+storage
+unhandledrejection
+unload
```

```diff
# api.MathMLElement (110 added)
+abort
+animationcancel
+animationend
+animationiteration
+animationstart
+auxclick
+beforeinput
+beforematch
+beforetoggle
+beforexrselect
+blur
+cancel
+canplay
+canplaythrough
+change
+click
+close
+command
+contextlost
+contextmenu
+contextrestored
+copy
+cuechange
+cut
+dblclick
+drag
+dragend
+dragenter
+dragexit
+dragleave
+dragover
+dragstart
+drop
+durationchange
+emptied
+ended
+error
+fencedtreeclick
+focus
+formdata
+gotpointercapture
+input
+invalid
+keydown
+keypress
+keyup
+load
+loadeddata
+loadedmetadata
+loadend
+loadstart
+lostpointercapture
+mousedown
+mouseenter
+mouseleave
+mousemove
+mouseout
+mouseover
+mouseup
+mousewheel
+paste
+pause
+play
+playing
+pointercancel
+pointerdown
+pointerenter
+pointerleave
+pointermove
+pointerout
+pointerover
+pointerrawupdate
+pointerup
+progress
+ratechange
+reset
+resize
+scroll
+scrollend
+search
+securitypolicyviolation
+seeked
+seeking
+select
+selectionchange
+selectstart
+slotchange
+snapchanged
+snapchanging
+stalled
+submit
+suspend
+timeupdate
+toggle
+touchcancel
+touchend
+touchforcechange
+touchmove
+touchstart
+transitioncancel
+transitionend
+transitionrun
+transitionstart
+volumechange
+waiting
+webkitanimationend
+webkitanimationiteration
+webkitanimationstart
+webkittransitionend
+wheel
```

```diff
# api.SVGElement (108 added)
+abort
+animationcancel
+animationend
+animationiteration
+animationstart
+auxclick
+beforeinput
+beforematch
+beforetoggle
+beforexrselect
+blur
+cancel
+canplay
+canplaythrough
+change
+click
+close
+command
+contextlost
+contextmenu
+contextrestored
+copy
+cuechange
+cut
+dblclick
+drag
+dragend
+dragenter
+dragexit
+dragleave
+dragover
+dragstart
+drop
+durationchange
+emptied
+ended
+fencedtreeclick
+focus
+formdata
+gotpointercapture
+input
+invalid
+keydown
+keypress
+keyup
+loadeddata
+loadedmetadata
+loadend
+loadstart
+lostpointercapture
+mousedown
+mouseenter
+mouseleave
+mousemove
+mouseout
+mouseover
+mouseup
+mousewheel
+paste
+pause
+play
+playing
+pointercancel
+pointerdown
+pointerenter
+pointerleave
+pointermove
+pointerout
+pointerover
+pointerrawupdate
+pointerup
+progress
+ratechange
+reset
+resize
+scroll
+scrollend
+search
+securitypolicyviolation
+seeked
+seeking
+select
+selectionchange
+selectstart
+slotchange
+snapchanged
+snapchanging
+stalled
+submit
+suspend
+timeupdate
+toggle
+touchcancel
+touchend
+touchforcechange
+touchmove
+touchstart
+transitioncancel
+transitionend
+transitionrun
+transitionstart
+volumechange
+waiting
+webkitanimationend
+webkitanimationiteration
+webkitanimationstart
+webkittransitionend
+wheel
```

```diff
# api.SVGSVGElement (21 added)
+afterprint
+beforeprint
+beforeunload
+gamepadconnected
+gamepaddisconnected
+hashchange
+languagechange
+message
+messageerror
+offline
+online
+pagehide
+pagereveal
+pageshow
+pageswap
+popstate
+portalactivate
+rejectionhandled
+storage
+unhandledrejection
+unload
```

