### PR TITLE
Ignore revert-rule global CSS keyword

### DIFF
--- a/test-builder/css.ts
+++ b/test-builder/css.ts
@@ -346,6 +346,7 @@ const remapPropertyValues = (input, types) => {
         "initial",
         "revert",
         "revert-layer",
+        "revert-rule",
         "unset",
         ...ignoredColorNames,
       ].includes(val)


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/29489
Issue for actual mapping https://github.com/openwebdocs/mdn-bcd-collector/issues/3152
