### PR TITLE
Babelv8 migration: remove import assertion plugin

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,4 +1,3 @@
 {
-  "presets": ["@babel/preset-env"],
-  "plugins": ["@babel/plugin-syntax-import-assertions"]
+  "presets": ["@babel/preset-env"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
       "devDependencies": {
         "@babel/core": "7.29.7",
         "@babel/eslint-parser": "7.29.7",
-        "@babel/plugin-syntax-import-assertions": "7.29.7",
         "@babel/preset-env": "7.29.7",
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^9.39.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "devDependencies": {
     "@babel/core": "7.29.7",
     "@babel/eslint-parser": "7.29.7",
-    "@babel/plugin-syntax-import-assertions": "7.29.7",
     "@babel/preset-env": "7.29.7",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
See https://babeljs.io/docs/v8-migration/#babel-plugin-syntax-import-assertions

Hopefully unblocks https://github.com/openwebdocs/mdn-bcd-collector/pull/3216