### PR TITLE
Remove cheerio and core-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,8 +58,6 @@
         "chai": "^6.2.2",
         "chai-as-promised": "8.0.2",
         "chai-http": "5.1.2",
-        "cheerio": "^1.2.0",
-        "core-js": "^3.49.0",
         "css-tree": "^3.2.1",
         "ejs-lint": "^2.0.1",
         "enquirer": "2.4.1",
@@ -5683,18 +5681,6 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,6 @@
     "chai": "^6.2.2",
     "chai-as-promised": "8.0.2",
     "chai-http": "5.1.2",
-    "cheerio": "^1.2.0",
-    "core-js": "^3.49.0",
     "css-tree": "^3.2.1",
     "ejs-lint": "^2.0.1",
     "enquirer": "2.4.1",


### PR DESCRIPTION
As far as I can tell this was added when importing the es-scraper code (https://github.com/openwebdocs/mdn-bcd-collector/commit/2b3d1947197358928773f6a956ba236722ae4d77) but not removed when using the es-scraper package (https://github.com/openwebdocs/mdn-bcd-collector/commit/71b30b8e9aea2edd9ad8fe16937de5b7dd912dee).