### PR TITLE
feat: replace test datalist with a searchable dropdown

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -111,6 +111,19 @@ select:disabled:hover,
   text-align: left;
   margin-left: -2px;
 }
+#test-selection::-webkit-input-placeholder {
+  color: white;
+}
+#test-selection::-moz-placeholder {
+  color: white;
+  opacity: 1;
+}
+#test-selection:-ms-input-placeholder {
+  color: white;
+}
+#test-selection::placeholder {
+  color: white;
+}
 
 footer {
   display: block;
@@ -219,8 +232,56 @@ h1 {
 
 #test-selection {
   padding-left: 16px;
-  width: 240px;
+  padding-right: 24px;
+  width: 215px;
   max-width: 70%;
+}
+#test-search {
+  color: white;
+  display: inline-block;
+  position: relative;
+  width: 300px;
+  max-width: 70%;
+}
+#test-search #test-selection {
+  max-width: 100%;
+}
+#test-search-caret {
+  position: absolute;
+  top: 13px;
+  right: 8px;
+  width: 0;
+  height: 0;
+  border-top: 6px solid white;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  cursor: pointer;
+}
+#test-dropdown {
+  position: absolute;
+  top: 100%;
+  left: -2px;
+  right: 0;
+  z-index: 1;
+  max-height: 250px;
+  overflow-y: auto;
+  background: white;
+  border: 1px solid #9900a1;
+  text-align: left;
+}
+#test-dropdown .test-option {
+  padding: 4px 8px;
+  color: black;
+  cursor: pointer;
+  word-break: break-all;
+}
+#test-dropdown .test-no-results {
+  padding: 4px 8px;
+  color: #636363;
+}
+#test-dropdown .test-option:hover,
+#test-dropdown .test-option.active {
+  background: #d2bbfd;
 }
 
 #supported-browsers {

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,12 +15,28 @@
   <h2>Run Tests</h2>
   <form id="test-form" action="/api/get" method="post">
     <div id="test-entry">
-      <datalist id="tests">
-        <% tests.forEach(function(test) { %>
-          <option value="<%- test %>"></option>
-        <% }); %>
-      </datalist>
-      <input id="test-selection" name="testSelection" list="tests" placeholder="All Tests">
+      <div id="test-search">
+        <input
+          id="test-selection"
+          name="testSelection"
+          type="text"
+          aria-label="Test"
+          placeholder="All Tests"
+          autocomplete="off"
+          role="combobox"
+          aria-autocomplete="list"
+          aria-controls="test-dropdown"
+          aria-expanded="false">
+        <span id="test-search-caret" aria-hidden="true"></span>
+        <div id="test-dropdown" class="hidden" role="listbox">
+          <% tests.forEach(function(test, i) { %>
+            <div id="test-option-<%= i %>" class="test-option" data-value="<%- test %>" role="option" aria-selected="false">
+              <%- test %>
+            </div>
+          <% }); %>
+          <div id="test-no-results" class="test-no-results hidden">No matching tests</div>
+        </div>
+      </div>
       <button name="submit" type="submit" id="start"><span class="mdi mdi-play"></span> Run</button>
     </div>
     <br>
@@ -71,15 +87,186 @@
 <script>
   function main() {
     var testSelection = document.getElementById('test-selection');
+    var testSearch = document.getElementById('test-search');
+    var testSearchCaret = document.getElementById('test-search-caret');
+    var testDropdown = document.getElementById('test-dropdown');
+    var testOptions = [];
+    var testNoResults = document.getElementById('test-no-results');
     var limitExposureBox = document.getElementById('limit-exposure-box');
+    var activeOption = -1;
 
-    testSelection.onchange = function() {
+    var testDropdownItems = testDropdown.getElementsByTagName('div');
+
+    for (var i = 0; i < testDropdownItems.length; i++) {
+      if (testDropdownItems[i].className == "test-option") {
+        testOptions[testOptions.length] = testDropdownItems[i];
+      }
+    }
+
+    function updateLimitExposure() {
       if (testSelection.value == '' || testSelection.value.indexOf('api') == 0) {
         limitExposureBox.style.display = "block";
       } else {
         limitExposureBox.style.display = "none";
       }
     }
+
+    function showDropdown() {
+      testDropdown.className = "";
+      testSelection.setAttribute("aria-expanded", "true");
+    }
+
+    function hideDropdown() {
+      testDropdown.className = "hidden";
+      testSelection.setAttribute("aria-expanded", "false");
+      testSelection.removeAttribute("aria-activedescendant");
+      activeOption = -1;
+    }
+
+    function visibleOptions() {
+      var visible = [];
+
+      for (var i = 0; i < testOptions.length; i++) {
+        if (testOptions[i].style.display != "none") {
+          visible[visible.length] = testOptions[i];
+        }
+      }
+
+      return visible;
+    }
+
+    function setActiveOption(next) {
+      var visible = visibleOptions();
+
+      for (var i = 0; i < testOptions.length; i++) {
+        testOptions[i].className = "test-option";
+        testOptions[i].setAttribute("aria-selected", "false");
+      }
+
+      if (!visible.length) {
+        activeOption = -1;
+        testSelection.removeAttribute("aria-activedescendant");
+        return;
+      }
+
+      activeOption = next;
+      if (activeOption < 0) {
+        activeOption = visible.length - 1;
+      } else if (activeOption >= visible.length) {
+        activeOption = 0;
+      }
+
+      visible[activeOption].className = "test-option active";
+      visible[activeOption].setAttribute("aria-selected", "true");
+      testSelection.setAttribute("aria-activedescendant", visible[activeOption].id);
+
+      if (visible[activeOption].offsetTop < testDropdown.scrollTop) {
+        testDropdown.scrollTop = visible[activeOption].offsetTop;
+      } else if (visible[activeOption].offsetTop + visible[activeOption].offsetHeight > testDropdown.scrollTop + testDropdown.clientHeight) {
+        testDropdown.scrollTop =
+          visible[activeOption].offsetTop +
+          visible[activeOption].offsetHeight -
+          testDropdown.clientHeight;
+      }
+    }
+
+    function filterTests() {
+      var query = testSelection.value.toLowerCase();
+      var hasMatches = false;
+
+      for (var i = 0; i < testOptions.length; i++) {
+        if (testOptions[i].getAttribute("data-value").toLowerCase().indexOf(query) == -1) {
+          testOptions[i].style.display = "none";
+        } else {
+          testOptions[i].style.display = "block";
+          hasMatches = true;
+        }
+        testOptions[i].className = "test-option";
+        testOptions[i].setAttribute("aria-selected", "false");
+      }
+
+      activeOption = -1;
+      testSelection.removeAttribute("aria-activedescendant");
+      testNoResults.className = hasMatches ? "test-no-results hidden" : "test-no-results";
+
+      showDropdown();
+    }
+
+    function chooseOption(option) {
+      testSelection.value = option.getAttribute("data-value");
+      updateLimitExposure();
+      hideDropdown();
+    }
+
+    testSelection.onchange = updateLimitExposure;
+    function showAllTests() {
+      for (var i = 0; i < testOptions.length; i++) {
+        testOptions[i].style.display = "block";
+        testOptions[i].className = "test-option";
+        testOptions[i].setAttribute("aria-selected", "false");
+      }
+      activeOption = -1;
+      testSelection.removeAttribute("aria-activedescendant");
+      testNoResults.className = "test-no-results hidden";
+      showDropdown();
+    }
+
+    testSelection.onfocus = showAllTests;
+    testSelection.onkeyup = function(event) {
+      event = event || window.event;
+
+      if (event.keyCode == 38 || event.keyCode == 40 || event.keyCode == 13 || event.keyCode == 27) {
+        return;
+      }
+
+      filterTests();
+      updateLimitExposure();
+    };
+    testSelection.onkeydown = function(event) {
+      event = event || window.event;
+
+      if (event.keyCode == 40) {
+        showDropdown();
+        setActiveOption(activeOption + 1);
+        return false;
+      } else if (event.keyCode == 38) {
+        showDropdown();
+        setActiveOption(activeOption - 1);
+        return false;
+      } else if (event.keyCode == 13 && activeOption > -1) {
+        chooseOption(visibleOptions()[activeOption]);
+        return false;
+      } else if (event.keyCode == 27) {
+        hideDropdown();
+        return false;
+      }
+    };
+    testSearchCaret.onmousedown = function() {
+      testSelection.focus();
+      showAllTests();
+      return false;
+    };
+
+    for (var i = 0; i < testOptions.length; i++) {
+      testOptions[i].onmousedown = function() {
+        chooseOption(this);
+        return false;
+      };
+    }
+
+    document.onclick = function(event) {
+      event = event || window.event;
+      var target = event.target || event.srcElement;
+
+      while (target) {
+        if (target == testSearch) {
+          return;
+        }
+        target = target.parentNode;
+      }
+
+      hideDropdown();
+    };
   }
 
   window.onload = main;


### PR DESCRIPTION
This PR replaces the native <datalist> used for test selection with a custom searchable dropdown.

Fixes: #3256 

What's changed:

- Added a searchable dropdown for selecting tests.
- Filters results as you type.
- Supports mouse and keyboard selection.
- Keeps the existing testSelection input and form behavior.
- No backend changes were required.

<img width="1917" height="951" alt="image" src="https://github.com/user-attachments/assets/42a93b95-cfda-43fc-ada2-389613375d5f" />
