### PR TITLE
Default deploy: limit collection to browsers from 2023 onwards

### DIFF
--- a/scripts/selenium.ts
+++ b/scripts/selenium.ts
@@ -787,7 +787,7 @@ if (esMain(import.meta)) {
           describe: "Limit to browser releases from this year on",
           alias: "s",
           type: "string",
-          default: "2020",
+          default: "2023",
           nargs: 1,
         })
         .option("os", {


### PR DESCRIPTION
The default deploy action collects compat data for ["chrome", "edge", "firefox", "safari"] from 2020 onwards. The action takes more than an hour to complete. I think this is not needed. To move quicker, only collect data from 2023 onwards. We could use that time rather for collecting additional browsers and (mobile) environments.

If we have new tests for older features, we have to verify anyways if it is available pre-2023 (or pre-2020 before this PR). In such cases, we can always manually collect data in older browsers or manually attempt to find the correct version.