### PR TITLE
Approve install scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,11 @@
     "typescript-eslint": "~8.65.0",
     "webidl2": "24.5.0",
     "yaml": "2.9.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true,
+    "fsevents@2.3.3": true,
+    "protobufjs@7.5.8": true,
+    "puppeteer@25.3.0": true
   }
 }


### PR DESCRIPTION
Fixes this warning:

```
npm warn allow-scripts 4 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   esbuild@0.28.1 (postinstall: node install.js)
npm warn allow-scripts   fsevents@2.3.3 (install: (install scripts present))
npm warn allow-scripts   protobufjs@7.5.8 (postinstall: node scripts/postinstall)
npm warn allow-scripts   puppeteer@25.3.0 (postinstall: node install.mjs)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```