### PR TITLE
Do not collect Chrome iOS and Edge Android

### DIFF
--- a/scripts/selenium.ts
+++ b/scripts/selenium.ts
@@ -744,7 +744,10 @@ const runAll = async (
     const browsertasks: ListrTask[] = [];
 
     const browserOsMap = {
+      chrome: ["macOS", "Windows"],
       chrome_android: ["Android"],
+      edge: ["macOS", "Windows"],
+      firefox: ["macOS", "Windows"],
       firefox_android: ["Android"],
       safari_ios: ["iOS"],
       safari: ["macOS"],


### PR DESCRIPTION
Specify OS environments for desktop browsers, too. Avoids these warnings (the browsers aren't in BCD)

```
warn: Ignoring unknown browser Chrome iOS 26.0 (Mozilla/5.0 (iPhone; CPU iPhone OS 26_0_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/137.0.7151.107 Mobile/15E148 Safari/604.1)
warn: Ignoring unknown browser Chrome iOS 26.2 (Mozilla/5.0 (iPhone; CPU iPhone OS 26_2_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/137.0.7151.107 Mobile/15E148 Safari/604.1)
warn: Ignoring unknown browser Chrome iOS 26.3 (Mozilla/5.0 (iPhone; CPU iPhone OS 26_3_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/137.0.7151.107 Mobile/15E148 Safari/604.1)
warn: Ignoring unknown browser Edge Android 145.0 (Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Mobile Safari/537.36 EdgA/145.0.0.0)
```
