### PR TITLE
Remove HTMLFramesetElement.onorientationchange

### DIFF
--- a/custom/idl/html.idl
+++ b/custom/idl/html.idl
@@ -113,10 +113,6 @@ partial interface HTMLElement {
   attribute HTMLMenuElement? contextMenu;
 };
 
-partial interface HTMLFrameSetElement {
-  attribute EventHandler onorientationchange;
-};
-
 partial interface HTMLInputElement {
   // https://github.com/whatwg/html/issues/667
   attribute boolean incremental;


### PR DESCRIPTION
This is non-standard (and not part of the Compat standard). I think we're not planning to record data for it.

Implementation might be Chrome (behind a runtime flag). https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/html_frame_set_element.idl