### PR TITLE
Remove non-standard HTMLMediaElement.allowedToPlay

### DIFF
--- a/custom/idl/html.idl
+++ b/custom/idl/html.idl
@@ -222,12 +222,6 @@ partial interface WorkerGlobalScope {
   undefined dump(any... data);
 };
 
-// Non-standard addition in Gecko
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1478208
-partial interface HTMLMediaElement {
-  readonly attribute boolean allowedToPlay;
-};
-
 // Non-standard
 
 partial interface HTMLElement {


### PR DESCRIPTION
This never made it to a release in over 6 years. Removing. Maybe it will come back standardized.