### PR TITLE
fix: handle GlobalEventHandlers in IDL flattening

### DIFF
--- a/custom/idl/event-handlers.idl
+++ b/custom/idl/event-handlers.idl
@@ -9,7 +9,6 @@ partial interface Document {
 
 partial interface Element {
   attribute EventHandler onafterscriptexecute;
-  attribute EventHandler onanimationcancel;
   attribute EventHandler onanimationend;
   attribute EventHandler onanimationiteration;
   attribute EventHandler onanimationstart;

--- a/custom/overrides.json
+++ b/custom/overrides.json
@@ -776,8 +776,6 @@
   ["api.Element.focusout_event", "firefox_android", "52+", true],
   ["api.VisualViewport.scrollend_event", "chrome", "114+", true],
   ["api.VisualViewport.scrollend_event", "edge", "114+", true],
-  ["api.Element.animationcancel_event", "chrome", "83+", true],
-  ["api.Element.animationcancel_event", "edge", "83+", true],
   ["api.SVGAnimationEvent.beginEvent_event", "safari", "10+", true],
   ["api.SVGAnimationEvent.beginEvent_event", "safari_ios", "10+", true],
   ["api.SVGAnimationEvent.endEvent_event", "safari", "10+", true],

--- a/test-builder/api.test.ts
+++ b/test-builder/api.test.ts
@@ -140,6 +140,102 @@ describe("build (API)", () => {
       assert.equal(globals[0].members[0].name, "atob");
     });
 
+    it("GlobalEventHandlers are mapped to their implementing interfaces", () => {
+      const ast = WebIDL2.parse(`
+        interface mixin GlobalEventHandlers {
+          attribute EventHandler onanimationcancel;
+        };
+
+        interface Element {
+        };
+
+        interface HTMLElement : Element {
+        };
+
+        interface SVGElement : Element {
+        };
+
+        interface MathMLElement : Element {
+        };
+
+        interface Document {
+        };
+
+        interface Window {
+        };
+
+        HTMLElement includes GlobalEventHandlers;
+        SVGElement includes GlobalEventHandlers;
+        MathMLElement includes GlobalEventHandlers;
+        Document includes GlobalEventHandlers;
+        Window includes GlobalEventHandlers;
+      `);
+
+      const {ast: flattenedAST} = flattenIDL({test: ast}, {});
+
+      const element = flattenedAST.find(
+        (dfn) => "name" in dfn && dfn.name === "Element",
+      );
+      const htmlElement = flattenedAST.find(
+        (dfn) => "name" in dfn && dfn.name === "HTMLElement",
+      );
+      const svgElement = flattenedAST.find(
+        (dfn) => "name" in dfn && dfn.name === "SVGElement",
+      );
+      const mathMLElement = flattenedAST.find(
+        (dfn) => "name" in dfn && dfn.name === "MathMLElement",
+      );
+      const document = flattenedAST.find(
+        (dfn) => "name" in dfn && dfn.name === "Document",
+      );
+      const window = flattenedAST.find(
+        (dfn) => "name" in dfn && dfn.name === "Window",
+      );
+      assert.equal(
+        element?.type === "interface" &&
+          element.members.some((member) => member.name === "onanimationcancel"),
+        false,
+      );
+
+      assert.equal(
+        htmlElement?.type === "interface" &&
+          htmlElement.members.some(
+            (member) => member.name === "onanimationcancel",
+          ),
+        true,
+      );
+
+      assert.equal(
+        svgElement?.type === "interface" &&
+          svgElement.members.some(
+            (member) => member.name === "onanimationcancel",
+          ),
+        true,
+      );
+
+      assert.equal(
+        mathMLElement?.type === "interface" &&
+          mathMLElement.members.some(
+            (member) => member.name === "onanimationcancel",
+          ),
+        true,
+      );
+
+      assert.equal(
+        document?.type === "interface" &&
+          document.members.some(
+            (member) => member.name === "onanimationcancel",
+          ),
+        true,
+      );
+
+      assert.equal(
+        window?.type === "interface" &&
+          window.members.some((member) => member.name === "onanimationcancel"),
+        true,
+      );
+    });
+
     it("mixin missing", () => {
       const specIDLs = {
         first: WebIDL2.parse(

--- a/test-builder/api.ts
+++ b/test-builder/api.ts
@@ -86,7 +86,6 @@ const flattenIDL = (specIDLs: IDLFiles, customIDLs: IDLFiles) => {
     if (dfn.type === "includes") {
       const skipIncludes = [
         "WindowOrWorkerGlobalScope", // handled separately as globals
-        "GlobalEventHandlers", // XXX needs special handling
         "WindowEventHandlers", // XXX needs special handling
       ];
       if (skipIncludes.includes(dfn.includes)) {
@@ -115,9 +114,28 @@ const flattenIDL = (specIDLs: IDLFiles, customIDLs: IDLFiles) => {
           `Target ${dfn.target} not found for interface mixin ${dfn.includes}`,
         );
       }
-
       // merge members to target interface
-      mergeMembers(target, mixin);
+      if (
+        dfn.includes === "GlobalEventHandlers" &&
+        target.type === "interface" &&
+        mixin.type === "interface mixin"
+      ) {
+        const existingMembers = new Set(
+          target.members
+            .filter((member) => "name" in member)
+            .map((member) => member.name),
+        );
+
+        mergeMembers(target, {
+          ...mixin,
+          members: mixin.members.filter(
+            (member) =>
+              !("name" in member) || !existingMembers.has(member.name),
+          ),
+        });
+      } else {
+        mergeMembers(target, mixin);
+      }
     }
   }
 


### PR DESCRIPTION
#### Summary

Update the IDL flattening logic to correctly process the `GlobalEventHandlers` interface mixin.

Previously, `GlobalEventHandlers` was skipped during IDL flattening, which prevented event handler members such as `onanimationcancel` from being mapped to their implementing interfaces. Removing the skip directly caused duplicate member definitions for handlers that are already explicitly defined on target interfaces.

This change merges `GlobalEventHandlers` members into their implementing interfaces while avoiding duplicate definitions.

#### Changes

- Stop skipping `GlobalEventHandlers` during IDL flattening.
- Avoid adding `GlobalEventHandlers` members that already exist on the target interface.
- Remove the now-unnecessary `Element.onanimationcancel` custom IDL definition.
- Remove the corresponding Chrome and Edge overrides for `api.Element.animationcancel_event`.
- Add a regression test covering `HTMLElement`, `SVGElement`, `MathMLElement`, `Document`, and `Window`.

#### Test results

- `npx tsx test-builder/index.ts` — passed
- `npm run build` — passed
- `npm test` — passed
- `npx tsx --test --test-name-pattern="GlobalEventHandlers are mapped" test-builder/api.test.ts` — passed
- `git diff --check` — passed

#### Related issues

- Addresses [mdn/browser-compat-data#29376](https://github.com/mdn/browser-compat-data/issues/29376), which exposed the incorrect handling of `GlobalEventHandlers` in the collector.
- Related to [openwebdocs/mdn-bcd-collector#1111](https://github.com/openwebdocs/mdn-bcd-collector/issues/1111), which tracks support for `GlobalEventHandlers` and `WindowEventHandlers` in the collector.