### PR TITLE
fix: use valid text-box-edge cap and ex tests

### DIFF
--- a/custom/tests.yaml
+++ b/custom/tests.yaml
@@ -6262,6 +6262,11 @@ css:
       __test: return CSS.supports('color', 'var(--foo)') || CSS.supports('color', 'env(--foo)');
     aspect-ratio: |-
       return bcd.testCSSProperty('aspect-ratio', '16 / 9');
+    text-box-edge:
+      cap:
+        __test: return bcd.testCSSProperty('text-box-edge', 'cap alphabetic');
+      ex:
+        __test: return bcd.testCSSProperty('text-box-edge', 'ex alphabetic');
   selectors:
     next-sibling: return bcd.testCSSSelector('div + span');
     child: return bcd.testCSSSelector('div > span');

--- a/test-builder/css.test.ts
+++ b/test-builder/css.test.ts
@@ -90,6 +90,55 @@ describe("build (CSS)", () => {
     });
   });
 
+  it("custom test for CSS property values", async () => {
+    const webrefCSS = {
+      properties: [
+        {
+          name: "text-box-edge",
+          href: "https://foo.bar",
+          syntax: "[ text | cap | ex ] [ text | alphabetic ]?",
+        },
+      ],
+      selectors: [],
+      types: [],
+    };
+
+    const customCSS = {
+      properties: {},
+      selectors: {},
+      types: {},
+    };
+
+    assert.deepEqual(await build(webrefCSS, customCSS), {
+      "css.properties.text-box-edge": {
+        code: 'bcd.testCSSProperty("text-box-edge")',
+        exposure: ["Window"],
+      },
+      "css.properties.text-box-edge.alphabetic": {
+        code: 'bcd.testCSSProperty("text-box-edge", "alphabetic")',
+        exposure: ["Window"],
+      },
+      "css.properties.text-box-edge.cap": {
+        code: `(function () {
+  return bcd.testCSSProperty("text-box-edge", "cap alphabetic");
+})();
+`,
+        exposure: ["Window"],
+      },
+      "css.properties.text-box-edge.ex": {
+        code: `(function () {
+  return bcd.testCSSProperty("text-box-edge", "ex alphabetic");
+})();
+`,
+        exposure: ["Window"],
+      },
+      "css.properties.text-box-edge.text": {
+        code: 'bcd.testCSSProperty("text-box-edge", "text")',
+        exposure: ["Window"],
+      },
+    });
+  });
+
   it("with custom test", async () => {
     const css = {
       properties: [{name: "foo", href: "https://foo.bar"}],

--- a/unittest/custom-tests.test.yaml
+++ b/unittest/custom-tests.test.yaml
@@ -130,6 +130,11 @@ css:
   properties:
     foo: return 1;
     bar: <%css.properties.foo:a%>
+    text-box-edge:
+      cap:
+        __test: return bcd.testCSSProperty('text-box-edge', 'cap alphabetic');
+      ex:
+        __test: return bcd.testCSSProperty('text-box-edge', 'ex alphabetic');
 
 javascript:
   builtins:


### PR DESCRIPTION
## Summary

Fix the custom tests for `css.properties.text-box-edge.cap` and `.ex` to use valid two-value forms instead of testing invalid standalone values.

## Test results and supporting details

- `npm run format` ✅
- `$env:NODE_ENV="test"; npx tsx --test .\test-builder\css.test.ts` ✅ (9/9 tests passed)
- Full `npm test -- test-builder/css.test.ts` could not complete on Windows because the repository script uses POSIX `NODE_ENV=test` syntax; the direct test run above passed.
- Added a regression test covering the `cap` and `ex` custom-test overrides.

## Related issues

Closes #3107