### PR TITLE
Disable dependabot cooldown for mdn & webref

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,18 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      exclude:
+         - "@mdn/*"
+         - "@webref/*"
     groups:
       data:
         patterns:
-          - "@webref/*"
+          - "@mdn/*"
+          - "@webref/*
       dev:
         exclude-patterns:
+          - "@mdn/*"
           - "@webref/*"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
See https://github.blog/changelog/2026-07-14-dependabot-version-updates-introduce-default-package-cooldown/