### PR TITLE
Add <camera> and <microphone> elements

### DIFF
--- a/custom/elements.json
+++ b/custom/elements.json
@@ -115,6 +115,7 @@
         "value"
       ]
     },
+    "camera": {},
     "canvas": {"attributes": ["height", "width"]},
     "caption": {"attributes": ["align"]},
     "col": {
@@ -332,6 +333,7 @@
     "meter": {
       "attributes": ["high", "low", "max", "min", "optimum", "value"]
     },
+    "microphone": {},
     "model": {
       "attributes": [
         "autoplay",


### PR DESCRIPTION
From https://w3c.github.io/mediacapture-extensions/#media-capture-html-elements which is also now added to web-specs, so the IDL should soon be available to the Collector, too.