### PR TITLE
Remove versions from allowScripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,9 +108,9 @@
     "yaml": "2.9.0"
   },
   "allowScripts": {
-    "esbuild@0.28.1": true,
-    "fsevents@2.3.3": true,
-    "protobufjs@7.5.8": true,
-    "puppeteer@25.4.0": true
+    "esbuild": true,
+    "fsevents": true,
+    "protobufjs": true,
+    "puppeteer": true
   }
 }


### PR DESCRIPTION
I think we want to allow this regardless of the version; otherwise you end up with warnings whenever they update.

```
npm warn allow-scripts 2 packages have install scripts not yet covered by allowScripts:
npm warn allow-scripts   protobufjs@7.6.5 (postinstall: node scripts/postinstall)
npm warn allow-scripts   puppeteer@25.9.0 (postinstall: node install.mjs)
npm warn allow-scripts
npm warn allow-scripts Run `npm approve-scripts --allow-scripts-pending` to review, or `npm approve-scripts <pkg>` to allow.
```