### PR TITLE
Create releases with statistics release artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,13 @@ jobs:
         run: |
           git tag v${{steps.check.outputs.version}}
           git push origin v${{steps.check.outputs.version}}
+      - name: Upload release-stats artifact
+        if: github.repository == 'openwebdocs/mdn-bcd-collector'
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+         npm run release-stats --silent -- > stats.json
+         gh release upload stats.json
       - name: Deploy to Heroku
         if: steps.check.outputs.changed == 'true'
         uses: akhileshns/heroku-deploy@v3.15.15

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
          npm run release-stats --silent -- > stats.json
-         gh release upload stats.json
+         gh release create v${{steps.check.outputs.version}} stats.json
       - name: Deploy to Heroku
         if: steps.check.outputs.changed == 'true'
         uses: akhileshns/heroku-deploy@v3.15.15

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git tag v${{steps.check.outputs.version}}
           git push origin v${{steps.check.outputs.version}}
-      - name: Upload release-stats artifact
+      - name: Create a release with artifacts
         if: github.repository == 'openwebdocs/mdn-bcd-collector'
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/app.ts
+++ b/app.ts
@@ -24,7 +24,7 @@ import appVersion from "./lib/app-version.js";
 import parseResults from "./lib/results.js";
 import getSecrets from "./lib/secrets.js";
 import {Report, ReportStore, Extensions, Exposure} from "./types/types.js";
-import {coverageData} from "./views/stats.js";
+import {coverageData} from "./scripts/release-stats.js";
 
 type RequestWithSession = Request & {
   session: expressSession.Session;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "find-missing-reports": "tsx scripts/find-missing-reports.ts",
     "add-new-bcd": "tsx scripts/add-new-bcd.ts",
     "release": "tsx scripts/release.ts",
-    "report-stats": "tsx scripts/report-stats.ts"
+    "report-stats": "tsx scripts/report-stats.ts",
+    "release-stats": "tsx ./scripts/release-stats.ts"
   },
   "dependencies": {
     "@google-cloud/logging-winston": "7.0.1",

--- a/scripts/release-stats.ts
+++ b/scripts/release-stats.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra";
 import bcd from "@mdn/browser-compat-data" with {type: "json"};
 import {getMissing} from "../lib/coverage.js";
 import appVersion from "../lib/app-version.js";
+import esMain from "es-main";
 
 const testsPath = new URL("../tests.json", import.meta.url);
 if (!fs.existsSync(testsPath)) {
@@ -79,3 +80,9 @@ const coverageData = {
 };
 
 export {coverageData};
+
+/* node:coverage disable */
+if (esMain(import.meta)) {
+  console.log(JSON.stringify(coverageData, undefined, 2));
+}
+/* node:coverage enable */


### PR DESCRIPTION
With every new version of the collector, capture the statistics available at https://collector.openwebdocs.org/stats as a stats.json release artifact, so that we can measure how things changed over time.

@ddbeck do you think this would do the trick? I'm basically trying to copy what you've done in web-features.

Edit: We weren't actually creating releases, so this does that now (I think).